### PR TITLE
Modified quantile GXG functions; option to take mean of quantiles per year

### DIFF
--- a/pastas/stats.py
+++ b/pastas/stats.py
@@ -639,11 +639,11 @@ def runs_test(series, tmin=None, tmax=None, cutoff="mean"):
 # noinspection PyIncorrectDocstring,PyIncorrectDocstring
 def q_ghg(series, tmin=None, tmax=None, q=0.94):
     """Gemiddeld Hoogste Grondwaterstand (GHG) also called MHGL (Mean High
-    Groundwater Level) Approximated by taking a quantile of the
-    timeseries values, after resampling to daily values.
+    Groundwater Level) Approximated by taking quantiles of the
+    timeseries values per year and taking the mean of the quantiles. 
 
-    This function does not care about series length!
-
+    The series is first resampled to daily values.
+ 
     Parameters
     ----------
     series: pandas.Series
@@ -658,17 +658,22 @@ def q_ghg(series, tmin=None, tmax=None, q=0.94):
         series = series.loc[tmin:]
     if tmax is not None:
         series = series.loc[:tmax]
-    series = series.resample('d').median()
-    return series.quantile(q)
+    q_yearly = (series
+        .resample('d')
+        .median()
+        .resample('a')
+        .apply(lambda s: s.quantile(q))
+        )
+    return q_yearly.mean()
 
 
 # noinspection PyIncorrectDocstring,PyIncorrectDocstring
 def q_glg(series, tmin=None, tmax=None, q=0.06):
     """Gemiddeld Laagste Grondwaterstand (GLG) also called MLGL (Mean Low
-    Groundwater Level) approximated by taking a quantile of the
-    timeseries values, after resampling to daily values.
+    Groundwater Level). Approximated by taking quantiles of the
+    timeseries values per year and calculating the mean of the quantiles. 
 
-    This function does not care about series length!
+    The series is first resampled to daily values.
 
     Parameters
     ----------
@@ -684,8 +689,13 @@ def q_glg(series, tmin=None, tmax=None, q=0.06):
         series = series.loc[tmin:]
     if tmax is not None:
         series = series.loc[:tmax]
-    series = series.resample('d').median()
-    return series.quantile(q)
+    q_yearly = (series
+        .resample('d')
+        .median()
+        .resample('a')
+        .apply(lambda s: s.quantile(q))
+        )
+    return q_yearly.mean()
 
 
 def q_gvg(series, tmin=None, tmax=None):

--- a/pastas/stats.py
+++ b/pastas/stats.py
@@ -659,20 +659,15 @@ def __q_gxg__(series, q, tmin=None, tmax=None, by_year=True):
         series = series.loc[tmin:]
     if tmax is not None:
         series = series.loc[:tmax]
+    series = series.resample('d').median()
     if by_year:
         return (series
-            .resample('d')
-            .median()
             .resample('a')
             .apply(lambda s: s.quantile(q))
             .mean()
             )
     else:
-        return (series
-            .resample('d')
-            .median()
-            .s.quantile(q)
-            )   
+        return series.quantile(q) 
 
 
 # noinspection PyIncorrectDocstring,PyIncorrectDocstring
@@ -751,10 +746,7 @@ def q_gvg(series, tmin=None, tmax=None, by_year=True):
                 .mean()
                 )
         else:
-            return (series
-                .loc[inspring]
-                .median()
-                )
+            return series.loc[inspring].median()
     else:
         return np.nan
 


### PR DESCRIPTION
* added base function __q_gxg__ for q_ghg and q_glg
* 'by_year' option to take mean of quantiles per year, default True
* updated docstrings accordingly

See issue #77 
