### PR TITLE
fix datetime x axis error in results plot

### DIFF
--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -108,12 +108,12 @@ class Plotting:
 
         # Residuals and noise
         ax2 = plt.subplot2grid((rows, 3), (2, 0), colspan=2, sharex=ax1)
-        ax2.axhline(0.0, color='k', linestyle='--')
         res = self.ml.residuals(tmin=tmin, tmax=tmax)
         res.plot(ax=ax2, sharex=ax1, color='k', x_compat=True)
         if self.ml.settings["noise"] and self.ml.noisemodel:
             noise = self.ml.noise(tmin=tmin, tmax=tmax)
             noise.plot(ax=ax2, sharex=ax1, x_compat=True)
+        ax2.axhline(0.0, color='k', linestyle='--', zorder=0)
         ax2.legend(loc=(0, 1), ncol=3, frameon=False)
         ax2.minorticks_off()
 


### PR DESCRIPTION
a horizontal line is added to the model result plot:
`ax2.axhline(0.0, color='k', linestyle='--')`

The `.axhline()` uses default values `xmin=0` and `xmax=1` therefore changing the dtype of the x-axis from datetime to some nummerical value. This causes errors later on if you want to plot timeseries on the same axis.

I solved this by plotting the horizontal line after the timeseries are plotted.