### PR TITLE
Time standardisation

### DIFF
--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -142,14 +142,12 @@ class NoiseModel(NoiseModelBase):
             Series of the noise.
 
         """
-        dt = get_dt(freq)
-        odelt = res.index.to_series().diff() / pd.Timedelta(dt, "D")
+        odelt = res.index.to_series().diff() / pd.Timedelta(1, 'd')
         odelt = odelt.iloc[1:]
-        alpha = parameters[0]
         noise = pd.Series(data=res)
+        alpha = parameters[0]
         # res.values is needed else it gets messed up with the dates
         noise.iloc[1:] -= np.exp(-odelt / alpha) * res.values[:-1]
-
         weights = self.weights(alpha, odelt)
         noise = noise.multiply(weights, fill_value=0.0)
         noise.name = "Noise"
@@ -222,7 +220,7 @@ class NoiseModel2(NoiseModelBase):
             Series of the noise.
 
         """
-        odelt = res.index.to_series().diff() / pd.Timedelta(1, freq)
+        odelt = res.index.to_series().diff() / pd.Timedelta(1, 'd')
         odelt = odelt.iloc[1:]
         noise = pd.Series(res)
         alpha = parameters[0]

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -69,7 +69,7 @@ class TimeSeries(object):
                  "fill_nan": "interpolate"},
         "well": {"sample_up": "bfill", "sample_down": "mean",
                  "fill_nan": 0.0, "fill_before": 0.0, "fill_after": 0.0,
-                 "to_daily": "divide"},
+                 "to_daily_unit": "divide"},
         "waterlevel": {"sample_up": "interpolate", "sample_down": "mean",
                        "fill_before": "mean", "fill_after": "mean",
                        "fill_nan": "interpolate"},
@@ -117,7 +117,7 @@ class TimeSeries(object):
 
             self.freq_original = freq_original
             self.settings = {
-                "to_daily": None,
+                "to_daily_unit": None,
                 "freq": None,
                 "sample_up": None,
                 "sample_down": None,
@@ -366,7 +366,7 @@ class TimeSeries(object):
             series = self.series_validated.copy(deep=True)
 
             # Update the series with the new settings
-            series = self.to_daily(series)
+            series = self.to_daily_unit(series)
             series = self.change_frequency(series)
             series = self.fill_before(series)
             series = self.fill_after(series)
@@ -410,8 +410,8 @@ class TimeSeries(object):
 
         return series
 
-    def to_daily(self, series):
-        method = self.settings["to_daily"]
+    def to_daily_unit(self, series):
+        method = self.settings["to_daily_unit"]
         if method is not None:
             if method == True or method == "divide":
                 dt = series.index.to_series().diff() / pd.Timedelta(1, 'd')
@@ -422,7 +422,7 @@ class TimeSeries(object):
                         "values with: %s" % (self.name, method))
             else:
                 logger.warning(
-                    "Time Series %s: User-defined option for to_daily %s is not "
+                    "Time Series %s: User-defined option for to_daily_unit %s is not "
                     "supported" % (self.name, method))
         return series
 

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -62,13 +62,14 @@ class TimeSeries(object):
     """
     _predefined_settings = {
         "oseries": {"fill_nan": "drop", "sample_down": "drop"},
-        "prec": {"sample_up": "divide", "sample_down": "sum",
+        "prec": {"sample_up": "bfill", "sample_down": "mean",
                  "fill_nan": 0.0, "fill_before": "mean", "fill_after": "mean"},
-        "evap": {"sample_up": "divide", "sample_down": "sum",
+        "evap": {"sample_up": "bfill", "sample_down": "mean",
                  "fill_before": "mean", "fill_after": "mean",
                  "fill_nan": "interpolate"},
-        "well": {"sample_up": "divide", "sample_down": "sum",
-                 "fill_nan": 0.0, "fill_before": 0.0, "fill_after": 0.0},
+        "well": {"sample_up": "bfill", "sample_down": "mean",
+                 "fill_nan": 0.0, "fill_before": 0.0, "fill_after": 0.0,
+                 "to_daily": "divide"},
         "waterlevel": {"sample_up": "interpolate", "sample_down": "mean",
                        "fill_before": "mean", "fill_after": "mean",
                        "fill_nan": "interpolate"},
@@ -116,6 +117,7 @@ class TimeSeries(object):
 
             self.freq_original = freq_original
             self.settings = {
+                "to_daily": None,
                 "freq": None,
                 "sample_up": None,
                 "sample_down": None,
@@ -364,6 +366,7 @@ class TimeSeries(object):
             series = self.series_validated.copy(deep=True)
 
             # Update the series with the new settings
+            series = self.to_daily(series)
             series = self.change_frequency(series)
             series = self.fill_before(series)
             series = self.fill_after(series)
@@ -405,6 +408,22 @@ class TimeSeries(object):
         series = series.loc[
                  series.first_valid_index():series.last_valid_index()]
 
+        return series
+
+    def to_daily(self, series):
+        method = self.settings["to_daily"]
+        if method is not None:
+            if method == True or method == "divide":
+                dt = series.index.to_series().diff() / pd.Timedelta(1, 'd')
+                if not (dt == 1.0).all():
+                    series = series / dt
+                    logger.info(
+                        "Time Series %s: values were transfered to daily "
+                        "values with: %s" % (self.name, method))
+            else:
+                logger.warning(
+                    "Time Series %s: User-defined option for to_daily %s is not "
+                    "supported" % (self.name, method))
         return series
 
     def sample_up(self, series):


### PR DESCRIPTION
As discussed on the meeting of the 8th of May (see [the presentation](https://docs.google.com/presentation/d/1NWe86KxzMd2_lTNHpBdYFXYgdKm380i-ubj96JXBup4/edit?usp=sharing)), here are some changes to standardise some time-properties of a model. These changes make sure:

- that the noise_alpha has the unit days, just like the warmup;
- that the parameter-values do not change when the frequency of the model is changed;
- that the user still has the option to convert series to daily values when needed (for example monthly well-extractions), with the 'to_daily'-setting.