### PR TITLE
change default parameters for steptrend

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -102,7 +102,7 @@ class Model:
         }
 
         if constant:
-            constant = Constant(value=self.oseries.series.mean(),
+            constant = Constant(initial=self.oseries.series.mean(),
                                 name="constant")
             self.add_constant(constant)
         if noisemodel:

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -150,16 +150,16 @@ class Gamma(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up is None:
-            parameters.loc[name + '_A'] = (1 / self.meanstress, 
-                                          -100 / self.meanstress,
-                                           100 / self.meanstress, 1, name)
-        elif self.up:
+        if self.up:
             parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
                                            100 / self.meanstress, 1, name)
-        else:
+        elif self.up is False:
             parameters.loc[name + '_A'] = (-1 / self.meanstress,
                                            -100 / self.meanstress, 0, 1, name)
+        else:
+            parameters.loc[name + '_A'] = (1 / self.meanstress,
+                                           np.nan, np.nan, 1, name)
+
         # if n is too small, the length of the response function is close to zero
         parameters.loc[name + '_n'] = (1, 0.1, 10, 1, name)
         parameters.loc[name + '_a'] = (10, 0.01, 5000, 1, name)
@@ -213,16 +213,16 @@ class Exponential(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up is None:
-            parameters.loc[name + '_A'] = (
-                1 / self.meanstress, -100 / self.meanstress, 
-                100 / self.meanstress, 1, name)
-        elif self.up:
-            parameters.loc[name + '_A'] = (
-                1 / self.meanstress, 0, 100 / self.meanstress, 1, name)
+        if self.up:
+            parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
+                                           100 / self.meanstress, 1, name)
+        elif self.up is False:
+            parameters.loc[name + '_A'] = (-1 / self.meanstress,
+                                           -100 / self.meanstress, 0, 1, name)
         else:
-            parameters.loc[name + '_A'] = (
-                -1 / self.meanstress, -100 / self.meanstress, 0, 1, name)
+            parameters.loc[name + '_A'] = (1 / self.meanstress,
+                                           np.nan, np.nan, 1, name)
+
         parameters.loc[name + '_a'] = (10, 0.01, 5000, 1, name)
         return parameters
 
@@ -292,16 +292,16 @@ class Hantush(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up is None:
-            parameters.loc[name + '_A'] = (
-                1 / self.meanstress, -100 / self.meanstress, 
-                100 / self.meanstress, 1, name)
-        elif self.up:
-            parameters.loc[name + '_A'] = (
-                1 / self.meanstress, 0, 100 / self.meanstress, 1, name)
+        if self.up:
+            parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
+                                           100 / self.meanstress, 1, name)
+        elif self.up is False:
+            parameters.loc[name + '_A'] = (-1 / self.meanstress,
+                                           -100 / self.meanstress, 0, 1, name)
         else:
-            parameters.loc[name + '_A'] = (
-                -1 / self.meanstress, -100 / self.meanstress, 0, 1, name)
+            parameters.loc[name + '_A'] = (1 / self.meanstress,
+                                           np.nan, np.nan, 1, name)
+
         parameters.loc[name + '_rho'] = (1, 1e-4, 10, 1, name)
         parameters.loc[name + '_cS'] = (100, 1e-3, 1e4, 1, name)
         return parameters
@@ -471,16 +471,16 @@ class FourParam(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up is None:
-            parameters.loc[name + '_A'] = (1 / self.meanstress, 
-                                          -100 / self.meanstress,
-                                           100 / self.meanstress, 1, name)
-        elif self.up:
+        if self.up:
             parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
                                            100 / self.meanstress, 1, name)
-        else:
+        elif self.up is False:
             parameters.loc[name + '_A'] = (-1 / self.meanstress,
                                            -100 / self.meanstress, 0, 1, name)
+        else:
+            parameters.loc[name + '_A'] = (1 / self.meanstress,
+                                           np.nan, np.nan, 1, name)
+
         parameters.loc[name + '_n'] = (1, -10, 10, 1, name)
         parameters.loc[name + '_a'] = (10, 0.01, 5000, 1, name)
         parameters.loc[name + '_b'] = (10, 0.01, 5000, 1, name)
@@ -659,16 +659,15 @@ class DoubleExponential(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up is None:
-            parameters.loc[name + '_A'] = (1 / self.meanstress, 
-                                          -100 / self.meanstress,
-                                           100 / self.meanstress, 1, name)
-        elif self.up:
+        if self.up:
             parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
                                            100 / self.meanstress, 1, name)
-        else:
+        elif self.up is False:
             parameters.loc[name + '_A'] = (-1 / self.meanstress,
                                            -100 / self.meanstress, 0, 1, name)
+        else:
+            parameters.loc[name + '_A'] = (1 / self.meanstress,
+                                           np.nan, np.nan, 1, name)
 
         parameters.loc[name + '_alpha'] = (0.1, 0.01, 0.99, 1, name)
         parameters.loc[name + '_a1'] = (10, 0.01, 5000, 1, name)

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -417,12 +417,13 @@ class One(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up is None:
-            parameters.loc[name + '_d'] = (1, -100, 100, 1, name)
-        elif self.up:
-            parameters.loc[name + '_d'] = (1, 0, 100, 1, name)
+        if self.up:
+            parameters.loc[name + '_d'] = (self.meanstress, 0, np.nan, 1, name)
+        elif self.up is False:
+            parameters.loc[name + '_d'] = (self.meanstress, np.nan, 0, 1, name)
         else:
-            parameters.loc[name + '_d'] = (-1, -100, 0, 1, name)
+            parameters.loc[name + '_d'] = (self.meanstress, np.nan, np.nan, 1,
+                                           name)
         return parameters
 
     def gain(self, p):

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -125,9 +125,9 @@ class Gamma(RfuncBase):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1
@@ -150,7 +150,11 @@ class Gamma(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up:
+        if self.up is None:
+            parameters.loc[name + '_A'] = (1 / self.meanstress, 
+                                          -100 / self.meanstress,
+                                           100 / self.meanstress, 1, name)
+        elif self.up:
             parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
                                            100 / self.meanstress, 1, name)
         else:
@@ -185,9 +189,9 @@ class Exponential(RfuncBase):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1
@@ -209,7 +213,11 @@ class Exponential(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up:
+        if self.up is None:
+            parameters.loc[name + '_A'] = (
+                1 / self.meanstress, -100 / self.meanstress, 
+                100 / self.meanstress, 1, name)
+        elif self.up:
             parameters.loc[name + '_A'] = (
                 1 / self.meanstress, 0, 100 / self.meanstress, 1, name)
         else:
@@ -241,9 +249,9 @@ class Hantush(RfuncBase):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1
@@ -284,7 +292,11 @@ class Hantush(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up:
+        if self.up is None:
+            parameters.loc[name + '_A'] = (
+                1 / self.meanstress, -100 / self.meanstress, 
+                100 / self.meanstress, 1, name)
+        elif self.up:
             parameters.loc[name + '_A'] = (
                 1 / self.meanstress, 0, 100 / self.meanstress, 1, name)
         else:
@@ -431,9 +443,9 @@ class FourParam(RfuncBase):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1
@@ -458,7 +470,11 @@ class FourParam(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up:
+        if self.up is None:
+            parameters.loc[name + '_A'] = (1 / self.meanstress, 
+                                          -100 / self.meanstress,
+                                           100 / self.meanstress, 1, name)
+        elif self.up:
             parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
                                            100 / self.meanstress, 1, name)
         else:
@@ -583,9 +599,9 @@ class FourParamQuad(FourParam):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1
@@ -616,9 +632,9 @@ class DoubleExponential(RfuncBase):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1
@@ -642,7 +658,11 @@ class DoubleExponential(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up:
+        if self.up is None:
+            parameters.loc[name + '_A'] = (1 / self.meanstress, 
+                                          -100 / self.meanstress,
+                                           100 / self.meanstress, 1, name)
+        elif self.up:
             parameters.loc[name + '_A'] = (1 / self.meanstress, 0,
                                            100 / self.meanstress, 1, name)
         else:
@@ -683,9 +703,9 @@ class Edelman(RfuncBase):
 
     Parameters
     ----------
-    up: bool, optional
+    up: bool or None, optional
         indicates whether a positive stress will cause the head to go up
-        (True, default) or down (False)
+        (True, default) or down (False), if None the head can go both ways.
     meanstress: float
         mean value of the stress, used to set the initial value such that
         the final step times the mean stress equals 1

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -405,7 +405,9 @@ class One(RfuncBase):
     def get_init_parameters(self, name):
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
-        if self.up:
+        if self.up is None:
+            parameters.loc[name + '_d'] = (1, -100, 100, 1, name)
+        elif self.up:
             parameters.loc[name + '_d'] = (1, 0, 100, 1, name)
         else:
             parameters.loc[name + '_d'] = (-1, -100, 0, 1, name)

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -239,8 +239,9 @@ class StressModel(StressModelBase):
         Response function used in the convolution with the stress.
     name: str
         Name of the stress.
-    up: Boolean, optional
+    up: Boolean or None, optional
         True if response function is positive (default), False if negative.
+        None if you don't want to define if response is positive or negative.
     cutoff: float, optional
         float between 0 and 1 to determine how long the response is (default
         is 99% of the actual response time). Used to reduce computation times.
@@ -331,7 +332,7 @@ class StressModel(StressModelBase):
             "stressmodel": self._name,
             "rfunc": self.rfunc._name,
             "name": self.name,
-            "up": True if self.rfunc.up == 1 else False,
+            "up": self.rfunc.up,
             "cutoff": self.rfunc.cutoff,
             "stress": self.dump_stress(series)
         }
@@ -352,8 +353,9 @@ class StressModel2(StressModelBase):
         Response function used in the convolution with the stress.
     name: str
         Name of the stress
-    up: Boolean, optional
+    up: Boolean or None, optional
         True if response function is positive (default), False if negative.
+        None if you don't want to define if response is positive or negative.
     cutoff: float
         float between 0 and 1 to determine how long the response is (default
         is 99% of the actual response time). Used to reduce computation times.
@@ -477,7 +479,7 @@ class StressModel2(StressModelBase):
             "stressmodel": self._name,
             "rfunc": self.rfunc._name,
             "name": self.name,
-            "up": True if self.rfunc.up == 1 else False,
+            "up": self.rfunc.up,
             "cutoff": self.rfunc.cutoff,
             "stress": self.dump_stress(series)
         }

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -508,7 +508,7 @@ class StepModel(StressModelBase):
     """
     _name = "StepModel"
 
-    def __init__(self, tstart, name, rfunc=One, up=True):
+    def __init__(self, tstart, name, rfunc=One, up=None):
         StressModelBase.__init__(self, rfunc, name, pd.Timestamp.min,
                                  pd.Timestamp.max, up, 1.0, 0.99)
         self.tstart = pd.Timestamp(tstart)

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -624,17 +624,13 @@ class Constant(StressModelBase):
     """
     _name = "Constant"
 
-    def __init__(self, name="constant", value=0.0, pmin=np.nan, pmax=np.nan):
-        self.value = value
-        self.pmin = pmin
-        self.pmax = pmax
+    def __init__(self, name="constant", initial=0.0):
         StressModelBase.__init__(self, One, name, pd.Timestamp.min,
-                                 pd.Timestamp.max, 1, 0, 0)
+                                 pd.Timestamp.max, None, initial, 0)
         self.set_init_parameters()
 
     def set_init_parameters(self):
-        self.parameters.loc[self.name + "_d"] = (
-            self.value, self.pmin, self.pmax, 1, self.name)
+        self.parameters = self.rfunc.get_init_parameters(self.name)
 
     def simulate(self, p=None):
         return p

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -540,7 +540,7 @@ class StepModel(StressModelBase):
             "stressmodel": self._name,
             'tstart': self.tstart,
             'name': self.name,
-            "up": True if self.rfunc.up == 1 else False,
+            "up": self.rfunc.up,
             'rfunc': self.rfunc._name
         }
         return data


### PR DESCRIPTION
Firstly I propose to add an option to set the parameter bounds in rfunc `One` to `-100` and `100`. Now there is only an option `up=True` to set them to `0` and `100` or `up=False` to set them to `-100` and `0`. You need the parameter bounds to be `-100` and `100` to fit positive and negative trends. At the moment you have to set the initial parameters manually.

Secondly, I propose to change the default parameter bounds of the `StepModel` to this new setting. Because by default you want to fit both negative and positive trends, even if you expect a positive trend. For example, if you think a positive trend will occur and you only try to fit positive trends you will end up with only positive trends even though at some points there is a negative trend. This might give you the wrong impression that only positive trends occur.