### PR TITLE
Use `loc` instead of `at` for adding metadata to the oseries dataframe

### DIFF
--- a/pastas/project/project.py
+++ b/pastas/project/project.py
@@ -126,7 +126,7 @@ class Project:
         # Transfer the metadata (x, y and z) to dataframe as well to increase speed.
         for i in ts.metadata.keys():
             value = ts.metadata[i]
-            data.at[name, i] = value
+            data.loc[name, i] = value
 
     def add_oseries(self, series, name=None, metadata=None, settings="oseries",
                     **kwargs):


### PR DESCRIPTION
When I use the code below to create a project with 2 oseries I get a ValueError: `ValueError: could not convert string to float: 'Dino'`. This occurs when using `data.at[name, i] = value` to set the `value` of the `source` column for `obs2`. 

```
df1 = pd.DataFrame(index=pd.date_range('2010-1-1', '2010-1-5'), data=[2,3,4,2,3])
df2 = pd.DataFrame(index=pd.date_range('2010-1-1', '2010-1-5'), data=[5,2,1,6,8])
meta1 = {'name': 'obs1', 'source':np.nan}
meta2 = {'name': 'obs2', 'source':'Dino'}
meta = [meta1, meta2]

pr = ps.Project('test')
for i, df in enumerate([df1, df2]):
    series = ps.TimeSeries(df, name=meta[i]['name'], metadata=meta[i])
    pr.add_series(series, kind='oseries')
```

When I add the first oseries a dataframe is created with a column `source` with a nan-value. The datatype of this column is `float`. When I try to add the second oseries it will try to set the value of the `source` column with a string `'Dino'`. I get an error because 'Dino' cannot be converted to a float (the datatype of the `source` column).

According to this post [https://stackoverflow.com/questions/37216485/pandas-at-versus-loc](url) the `at` method will give an error if the datatype of the value does not correspond to the datatype of the column. With the `loc` method I wont get an error, therefore I propose to change `at` to `loc` in this case. I know that `loc` is slightly slower than `at` but I don't think it will make a big difference here.