### PR TITLE
add check if noise_alpha is smaller than model freq

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -235,6 +235,12 @@ class Model:
         self.noisemodel.set_init_parameters(oseries=self.oseries.series)
         self.parameters = self.get_init_parameters(initial=False)
 
+        # check whether noise_alpha is not smaller than ml.settings["freq"]
+        freq_in_days = get_dt(self.settings["freq"])
+        noise_alpha = self.noisemodel.parameters.initial.iloc[0]
+        if freq_in_days > noise_alpha:
+            self.set_initial("noise_alpha", freq_in_days)
+
     @get_stressmodel
     def del_stressmodel(self, name):
         """ Safely delete a stressmodel from the stressmodels dict.


### PR DESCRIPTION
This small change is meant to address the issue that arises when a higher frequency oseries is used to create a model but the frequency in solve is set to 1 day (or longer). In this situation the noise_alpha parameter is too small, which can lead to the optimizer effectively "turning off" the noisemodel. 

There is a case in which this change might not be ideal, but I think this is preferable over the situation described above. With this change the following could occur:
- user creates model with oseries on freq 'H'
- default model settings is freq 'D', so noise_alpha is set to 1.0
- user wants to optimize on freq 'H', which means a better initial noise alpha might be 0.042.

The broader discussion here is is that the initial values of parameters are estimated based on data that might not be the same as the data that is used in `ml.solve()`. This is because the timeseries can be altered based on the kwargs provided to solve (i.e. freq, tmin, tmax). 

Some thoughts to consider:
- Should there be an option to (re-)estimate initial parameters in `ml.initialize()`?
- Perhaps a column could be added to ml.parameters to indicate whether parameters' initial values were manually adjusted? In that case we can re-estimate the non-adjusted parameters based on oseries_calib and leave the rest as the user intended...