### PR TITLE
Make default rfunc in StressModelBase None #186

### DIFF
--- a/examples/example_step.py
+++ b/examples/example_step.py
@@ -11,7 +11,7 @@ import pastas as ps
 obs = pd.read_csv("data/head_nb1.csv", index_col=0, parse_dates=True,
                   squeeze=True)
 # add 10 cm to the series from 2007
-obs["2007":] = obs["2007":] + 0.1
+obs["2007":] = obs["2007":] + 1.5
 
 # Create the time series model
 ml = ps.Model(obs)
@@ -28,7 +28,7 @@ sm = ps.StressModel2(stress=[rain, evap], rfunc=ps.Exponential,
 ml.add_stressmodel(sm)
 
 # add a stepmodel with an exponential response
-sm = ps.stressmodels.StepModel("2007", "Step", rfunc=ps.Exponential)
+sm = ps.stressmodels.StepModel("2007", "Step", rfunc=ps.One)
 ml.add_stressmodel(sm)
 
 # solve

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1443,7 +1443,7 @@ class Model:
         response: pandas.Series
 
         """
-        if not hasattr(self.stressmodels[name], "rfunc"):
+        if self.stressmodels[name].rfunc is None:
             raise TypeError("Stressmodel {} has no rfunc".format(name))
         else:
             block_or_step = getattr(self.stressmodels[name].rfunc,

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -517,7 +517,7 @@ class StepModel(StressModelBase):
     """
     _name = "StepModel"
 
-    def __init__(self, tstart, name, rfunc=One, up=None, cutoff=None):
+    def __init__(self, tstart, name, rfunc=One, up=True, cutoff=0.999):
         rfunc = rfunc(up=up, cutoff=cutoff, meanstress=1.0)
 
         StressModelBase.__init__(self, name=name, tmin=Timestamp.min,


### PR DESCRIPTION
# Short Description
- Allow rfunc to be none, when no response function is used in the stressmodel
- rfunc class is now instantiated in the stress model init, not in stressmodelbase

# Checklist before PR can be merged:
- [X] closes issue #186 
- [X] is documented
- [X] PEP8 compliant code
- [X] tests added / passed
- [x] passes Travis

ps. cool the new PR request submission format works now!