### PR TITLE
Add FerrisKnowles response function for wells

### DIFF
--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -2,12 +2,12 @@ import logging
 
 import pastas.recharge as rch
 from .model import Model
-from .noisemodels import NoiseModel, NoiseModel2
+from .noisemodels import NoiseModel, NoiseModel2, ArmaModel
 from .plots import TrackSolve
 from .project import Project
 from .read import read_meny, read_dino, read_knmi, read_waterbase
 from .rfunc import Gamma, Exponential, Hantush, Polder, One, FourParam, \
-    DoubleExponential, HantushWellModel
+    DoubleExponential, HantushWellModel, FerrisKnowles
 from .solver import LmfitSolve, LeastSquares
 from .stressmodels import StressModel, StressModel2, Constant, FactorModel, \
     RechargeModel, WellModel, StepModel, LinearTrend, TarsoModel


### PR DESCRIPTION
# Short Description
This PR adds the FerrisKnowles response function, as described in Shapoori et al (2015). Not sure about how to use  and interpret this function though:
- It has an indefinite integral so it keeps lowering the heads.
- I didn't scale  it yet so no gain parameter.

No idea if we want this, but we can add it as an experimental response function.

## Checklist before PR can be merged
- [ ] is documented
- [X] PEP8 compliant code
- [ ] tests added / passed
- [ ] passes Travis
- [ ] Example Notebook (for new features)
