### PR TITLE
Improve time_offset

### DIFF
--- a/examples/example_900.py
+++ b/examples/example_900.py
@@ -18,7 +18,6 @@ knmi = ps.read.knmi.KnmiStation.fromfile(
 rain = ps.TimeSeries(knmi.data['RD'], settings='prec')
 
 evap = ps.read_knmi('data/etmgeg_380.txt', variables='EV24')
-evap.freq_original = 'D'
 if True:
     # also add 9 hours to the evaporation
     s = evap.series_original
@@ -30,9 +29,6 @@ sm = ps.StressModel2(stress=[rain, evap], rfunc=ps.Exponential,
                      name='recharge')
 ml.add_stressmodel(sm)
 
-# set the time-offset of the model. This should be done automatically in the future.
-ml._set_time_offset()
-
 ## Solve
-ml.solve(freq='D')
+ml.solve()
 ml.plots.decomposition()

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -413,13 +413,11 @@ class Model:
         if tmin is None and self.settings['tmin']:
             tmin = self.settings['tmin']
         else:
-            tmin = self.get_tmin(tmin, freq, use_oseries=False,
-                                 use_stresses=True)
+            tmin = self.get_tmin(tmin, use_oseries=False, use_stresses=True)
         if tmax is None and self.settings['tmax']:
             tmax = self.settings['tmax']
         else:
-            tmax = self.get_tmax(tmax, freq, use_oseries=False,
-                                 use_stresses=True)
+            tmax = self.get_tmax(tmax, use_oseries=False, use_stresses=True)
         if freq is None:
             freq = self.settings["freq"]
         if warmup is None:
@@ -644,13 +642,11 @@ class Model:
         if tmin is None and self.settings['tmin']:
             tmin = self.settings['tmin']
         else:
-            tmin = self.get_tmin(tmin, freq, use_oseries=False,
-                                 use_stresses=True)
+            tmin = self.get_tmin(tmin, use_oseries=False, use_stresses=True)
         if tmax is None and self.settings['tmax']:
             tmax = self.settings['tmax']
         else:
-            tmax = self.get_tmax(tmax, freq, use_oseries=False,
-                                 use_stresses=True)
+            tmax = self.get_tmax(tmax, use_oseries=False, use_stresses=True)
         if freq is None:
             freq = self.settings["freq"]
 
@@ -1096,8 +1092,7 @@ class Model:
             sim_index = self.sim_index
         return sim_index
 
-    def get_tmin(self, tmin=None, freq=None, use_oseries=True,
-                 use_stresses=False):
+    def get_tmin(self, tmin=None, use_oseries=True, use_stresses=False):
         """Method that checks and returns valid values for tmin.
 
         Parameters
@@ -1105,8 +1100,6 @@ class Model:
         tmin: str, optional
             string with a year or date that can be turned into a pandas
             Timestamp (e.g. pd.Timestamp(tmin)).
-        freq: str, optional
-            string with the frequency.
         use_oseries: bool, optional
             Obtain the tmin and tmax from the oseries. Default is True.
         use_stresses: bool, optional
@@ -1160,8 +1153,7 @@ class Model:
 
         return tmin
 
-    def get_tmax(self, tmax=None, freq=None, use_oseries=True,
-                 use_stresses=False):
+    def get_tmax(self, tmax=None, use_oseries=True, use_stresses=False):
         """Method that checks and returns valid values for tmax.
 
         Parameters
@@ -1169,8 +1161,6 @@ class Model:
         tmax: str, optional
             string with a year or date that can be turned into a pandas
             Timestamp (e.g. pd.Timestamp(tmax)).
-        freq: str, optional
-            string with the frequency.
         use_oseries: bool, optional
             Obtain the tmin and tmax from the oseries. Default is True.
         use_stresses: bool, optional

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -454,7 +454,7 @@ class TimeSeries:
 
         # Drop nan-values at the beginning and end of the time series
         series = series.loc[
-                 series.first_valid_index():series.last_valid_index()]
+            series.first_valid_index():series.last_valid_index()]
 
         return series
 
@@ -554,10 +554,11 @@ class TimeSeries:
             msg = "Time Series {}: User-defined option for sample_down {} is" \
                   "not supported".format(self.name, method)
             logger.warning(msg)
-        
+
         if self.settings['time_offset'] > pd.Timedelta(0):
             # The offset is removed by the resample-method, so we will add it again
-            series.index = series.index + to_offset(self.settings["time_offset"])
+            series.index = series.index + \
+                to_offset(self.settings["time_offset"])
 
         logger.info("Time Series {} was sampled down to freq {} with method "
                     "{}".format(self.name, freq, method))

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -301,7 +301,7 @@ class TimeSeries:
             freq = self.settings['freq']
             if tmin is not None and freq is not None:
                 self.settings['time_offset'] = tmin - tmin.floor(freq)
-                
+
             # Get the validated series to start with
             series = self._series_validated.copy(deep=True)
 


### PR DESCRIPTION
See issue #207 and #231

# Short Description
This pull request finally solves the problem we have with the time-offset and also problems that arise when changing frequency. There are no new features, just existing ones that should work better. For example, you can now use any supported frequency (e.g. '7D') in example_900, so together with the time_offset of 9 hours. Also when a user now tries to use a model with two stresses that contain different time-offsets (for example daily precipitation at 9:00 and daily evaporation at 1:00, which is common in the netherlands), the user will receive an error explaining the problem, so he can solve it. In the past the model would fail because the simulation did not contain any values (see issue #207).

# Checklist before PR can be merged:
- [x] closes issue #207 and #231 
- [x] is documented (no new features)
- [x] PEP8 compliant code
- [x] tests added / passed (example_900.py)
- [x] passes Travis
- [x] Example Notebook (no new features)
- [x] API changes documented in Release Notes (no new features)
