### PR TITLE
Fix ml.get_stress() with WellModel

### DIFF
--- a/pastas/read/knmi.py
+++ b/pastas/read/knmi.py
@@ -363,7 +363,7 @@ class KnmiStation:
 
         # Adjust the unit of the measurements
         for key, value in self.variables.items():
-            # test if key existst in data
+            # test if key exists in data
             if key not in data.keys():
                 if key == 'YYYYMMDD' or key == 'HH':
                     pass

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -776,7 +776,9 @@ class WellModel(StressModelBase):
             h = h.add(Series(c, index=stress.index, fastpath=True),
                       fill_value=0.0)
         if istress is not None:
-            if self.stress[istress].name is not None:
+            if isinstance(istress, list):
+                h.name = self.name + "_" + "+".join(str(i) for i in istress)
+            elif self.stress[istress].name is not None:
                 h.name = self.stress[istress].name
             else:
                 h.name = self.name + "_" + str(istress)


### PR DESCRIPTION
# Short Description
Fixes #244:
- ml.get_stress("wells") for WellModel --> returns WellModel.simulate() result
- For WellModels `istress` keyword argument now accepts None, int or list of int
- `WellModel.get_stress()` now works as follows:
    - `istress=None` --> results in WellModel.simulate(), contribution of all stresses
    - `istress=0` --> timeseries of first stress only
    - `istress=[0, 1]`  --> WellModel.simulate() for first and second stress

# Checklist before PR can be merged:
- [x] closes issue #244 
- [ ] is documented
- [ ] PEP8 compliant code
- [ ] tests added / passed
- [x] passes Travis
~~- [ ] Example Notebook (for new features)~~
~~- [ ] API changes documented in Release Notes~~
