### PR TITLE
Fix ml.get_stress() for WellModel

### DIFF
--- a/pastas/read/knmi.py
+++ b/pastas/read/knmi.py
@@ -363,7 +363,7 @@ class KnmiStation:
 
         # Adjust the unit of the measurements
         for key, value in self.variables.items():
-            # test if key existst in data
+            # test if key exists in data
             if key not in data.keys():
                 if key == 'YYYYMMDD' or key == 'HH':
                     pass

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -776,7 +776,9 @@ class WellModel(StressModelBase):
             h = h.add(Series(c, index=stress.index, fastpath=True),
                       fill_value=0.0)
         if istress is not None:
-            if self.stress[istress].name is not None:
+            if isinstance(istress, list):
+                h.name = self.name + "_" + "+".join(str(i) for i in istress)
+            elif self.stress[istress].name is not None:
                 h.name = self.stress[istress].name
             else:
                 h.name = self.name + "_" + str(istress)


### PR DESCRIPTION
# Short Description
- `WellModel.get_stress()` returns `DataFrame` with stress in each column -> this also fixes `ml.get_stress()` for WellModels
- add support for istress as list of int for selecting only certain stresses
- convert `WellModel.distances` to `pd.Series` (so distances are labeled with name of stress)
- determine `WellModel.tmin/tmax` from series (previous implementation led to unexpected behavior when rounding to freq)

# Checklist before PR can be merged:
- [x] closes issue #244 
- [x] is documented
- [x] PEP8 compliant code
- [x] tests added / passed
- [x] passes Travis
- [x] ~~Example Notebook (for new features)~~
- [x] ~~API changes documented in Release Notes~~
