### PR TITLE
Update markdown cell to improve documentation

### DIFF
--- a/examples/notebooks/06_adding_trends.ipynb
+++ b/examples/notebooks/06_adding_trends.ipynb
@@ -271,6 +271,7 @@
    "source": [
     "## 4. Effect of system changes\n",
     "Sometimes changes to a groundwater system cannot be easily modelled using a step trend. For example when the system change causes a different response of the groundwater to recharge. In that case there are other methods to visualise the effect of the system change on the groundwater head. Two of these methods are shown below:\n",
+    "\n",
     "1. Fit the model on the observations before the system change. Use this model to simulate the groundwater head after the system change. The differences between simulated groundwater heads an observations are an indication of the effect of the system change on the groundwater head.\n",
     "2. similar to method 1. Now the model is fit on the period **after** the system change and groundwater heads are simulated for the period **before** the system change. "
    ]


### PR DESCRIPTION
While there is a line ending visible in the notebook before the introduction of methods 1 and 2 this enter is not shown in the documentation (https://pastas.readthedocs.io/en/dev/examples/006_adding_trends.ipynb.html). I think this can be solved by adding an extra enter.