### PR TITLE
pastas.plots.series() changes

### DIFF
--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -953,8 +953,12 @@ def series(head=None, stresses=None, hist=True, kde=False, titles=True,
     stresses: List of pd.Series
         List with Pandas time series with DatetimeIndex.
     hist: bool
-        Histogram for the Series. Returns the number of observations, mean,
-        skew and kurtosis as well. The number of bins is determined with Sturges rule.
+        Histogram for the series. The number of bins is determined with Sturges
+        rule. Returns the number of observations, mean, skew and kurtosis.
+    kde: bool
+        Kernel density estimate for the series. The kde is obtained from
+        scipy.gaussian_kde using scott to calculate the estimator bandwidth.
+        Returns the number of observations, mean, skew and kurtosis.
     titles: bool
         Set the titles or not. Taken from the name attribute of the Series.
     tmin: str or pd.Timestamp

--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -16,7 +16,7 @@ from matplotlib.ticker import MultipleLocator, LogFormatter
 from pandas import DataFrame, Timestamp, concat
 
 from .decorators import model_tmin_tmax
-from .stats import diagnostics, plot_cum_frequency, plot_diagnostics
+from .stats import plot_cum_frequency, plot_diagnostics
 
 logger = logging.getLogger(__name__)
 
@@ -1009,9 +1009,7 @@ def series(head=None, stresses=None, hist=True, titles=True,
             head_stats = [["Count", f"{head.count():0.0f}"],
                           ["Mean", f"{head.mean():0.2f}"],
                           ["Skew", f"{head.skew():0.2f}"],
-                          ["Kurtosis", f"{head.kurtosis():0.2f}"],
-                          ["Normality",
-                           f"{diagnostics(head).loc['Shapiroo','Reject H0']}"]]
+                          ["Kurtosis", f"{head.kurtosis():0.2f}"]]
             axes[0, 2].table(bbox=(0.0, 0.0, 1, 1), colWidths=(1.5, 1),
                              cellText=head_stats)
             axes[0, 2].axis("off")

--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -992,11 +992,10 @@ def series(head=None, stresses=None, hist=True, kde=False, titles=True,
         axes = axes[np.newaxis]
     elif cols == 1:
         axes = axes[:, np.newaxis]
-    if kde:
-        hist = False
-        axes[-1, 1].set_xlabel("Density [-]")
     if hist:
         axes[-1, 1].set_xlabel("Frequency [%]")
+    if kde:
+        axes[-1, 1].set_xlabel("Density [-]")
     if head is not None:
         head = head[tmin:tmax]
         head.plot(ax=axes[0, 0], marker=".", linestyle=" ", color="k")
@@ -1004,16 +1003,24 @@ def series(head=None, stresses=None, hist=True, kde=False, titles=True,
             axes[0, 0].set_title(head.name)
         if labels is not None:
             axes[0, 0].set_ylabel(labels[0])
-        if hist:
+        if hist and kde is False:
             head.hist(ax=axes[0, 1], orientation="horizontal", color="k",
                       weights=np.ones(len(head)) / len(head) * 100,
                       bins=int(np.ceil(1 + np.log2(len(head)))), grid=False)
+        if kde and hist:
+            head.hist(ax=axes[0, 1], orientation="horizontal", color="k",
+                      bins=int(np.ceil(1 + np.log2(len(head)))),
+                      grid=False, density=True)
         if kde:
             gkde = gaussian_kde(head, bw_method='scott')
             sample_range = np.nanmax(head) - np.nanmin(head)
             ind = np.linspace(np.nanmin(head) - 0.1 * sample_range,
                               np.nanmax(head) + 0.1 * sample_range, 1000)
-            axes[0, 1].plot(gkde.evaluate(ind), ind, color='k')
+            if hist:
+                colour = 'C5'
+            else:
+                colour = 'k'
+            axes[0, 1].plot(gkde.evaluate(ind), ind, color=colour)
         if hist or kde:
             # stats table
             head_stats = [["Count", f"{head.count():0.0f}"],
@@ -1033,20 +1040,28 @@ def series(head=None, stresses=None, hist=True, kde=False, titles=True,
             if labels is not None:
                 axes[i, 0].set_ylabel(labels[i])
             if hist:
-                if i > 0:
-                    axes[i, 0].sharex(axes[0, 0])
                 # histogram
                 stress.hist(ax=axes[i, 1], orientation="horizontal", color="k",
                             weights=np.ones(len(stress)) / len(stress) * 100,
                             bins=int(np.ceil(1 + np.log2(len(stress)))),
                             grid=False)
+            if kde and hist:
+                stress.hist(ax=axes[i, 1], orientation="horizontal", color="k",
+                            bins=int(np.ceil(1 + np.log2(len(stress)))),
+                            grid=False, density=True)
             if kde:
                 gkde = gaussian_kde(stress, bw_method='scott')
                 sample_range = np.nanmax(stress) - np.nanmin(stress)
                 ind = np.linspace(np.nanmin(stress) - 0.1 * sample_range,
                                   np.nanmax(stress) + 0.1 * sample_range, 1000)
-                axes[i, 1].plot(gkde.evaluate(ind), ind, color='k')
+                if hist:
+                    colour = 'C5'
+                else:
+                    colour = 'k'
+                axes[i, 1].plot(gkde.evaluate(ind), ind, color=colour)
             if hist or kde:
+                if i > 0:
+                    axes[i, 0].sharex(axes[0, 0])
                 # stats table
                 stress_stats = [["Count", f"{stress.count():0.0f}"],
                                 ["Mean", f"{stress.mean():0.2f}"],

--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -941,7 +941,7 @@ def compare(models, tmin=None, tmax=None, block_or_step='step', **kwargs):
     return axes
 
 
-def series(head=None, stresses=None, hist=True, bins=30, titles=True,
+def series(head=None, stresses=None, hist=True, titles=True,
            tmin=None, tmax=None, labels=None, figsize=(10, 5)):
     """Method to plot all the time series going into a Pastas Model.
 
@@ -953,10 +953,7 @@ def series(head=None, stresses=None, hist=True, bins=30, titles=True,
         List with Pandas time series with DatetimeIndex.
     hist: bool
         Histogram for the Series. Returns the number of observations, mean,
-        skew and kurtosis as well. For the head series the result of the
-        shapiro-wilk test (p > 0.05) for normality is reported.
-    bins: float
-        Number of bins in the histogram plot.
+        skew and kurtosis as well. The number of bins is determined with Sturges rule.
     titles: bool
         Set the titles or not. Taken from the name attribute of the Series.
     tmin: str or pd.Timestamp
@@ -1007,7 +1004,7 @@ def series(head=None, stresses=None, hist=True, bins=30, titles=True,
             # histogram
             head.hist(ax=axes[0, 1], orientation="horizontal", color="k",
                       weights=np.ones(len(head)) / len(head) * 100,
-                      bins=bins, grid=False)
+                      bins=int(np.ceil(1 + np.log2(len(head)))), grid=False)
             # stats table
             head_stats = [["Count", f"{head.count():0.0f}"],
                           ["Mean", f"{head.mean():0.2f}"],
@@ -1032,7 +1029,7 @@ def series(head=None, stresses=None, hist=True, bins=30, titles=True,
                 # histogram
                 stress.hist(ax=axes[i, 1], orientation="horizontal", color="k",
                             weights=np.ones(len(stress)) / len(stress) * 100,
-                            bins=bins, grid=False)
+                            bins=int(np.ceil(1 + np.log2(len(stress)))), grid=False)
                 # stats table
                 stress_stats = [["Count", f"{stress.count():0.0f}"],
                                 ["Mean", f"{stress.mean():0.2f}"],


### PR DESCRIPTION
# Short Description
Some small adjustments to the pastas.plots.series() function. Normality check is removed because it did not make sense. Additionally, the number bins in the histogram are now selected automatically according to [Sturge's Rule](https://accendoreliability.com/sturges-rule-method-selecting-number-bins-histogram/). 

Since histograms are difficult to interpret, there is now an option to plot the [kernel density estimate](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.plot.kde.html). 
![image](https://user-images.githubusercontent.com/66305055/139241592-ce0789bf-e872-417b-b041-f634efb28736.png)


# Checklist before PR can be merged:
- [x] is documented
- [x] PEP8 compliant code
