### PR TITLE
Save and read options of FlexModel to/from pas-file

### DIFF
--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -90,7 +90,11 @@ def _load_model(data):
         if "rfunc" in ts.keys():
             ts["rfunc"] = getattr(ps.rfunc, ts["rfunc"])
         if "recharge" in ts.keys():
-            ts["recharge"] = getattr(ps.recharge, ts["recharge"])()
+            recharge_kwargs = {}
+            if 'recharge_kwargs' in ts:
+                recharge_kwargs = ts["recharge_kwargs"]
+            ts["recharge"] = getattr(
+                ps.recharge, ts["recharge"])(**recharge_kwargs)
         if "stress" in ts.keys():
             for i, stress in enumerate(ts["stress"]):
                 _remove_keyword(stress)

--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -92,7 +92,7 @@ def _load_model(data):
         if "recharge" in ts.keys():
             recharge_kwargs = {}
             if 'recharge_kwargs' in ts:
-                recharge_kwargs = ts["recharge_kwargs"]
+                recharge_kwargs = ts.pop("recharge_kwargs")
             ts["recharge"] = getattr(
                 ps.recharge, ts["recharge"])(**recharge_kwargs)
         if "stress" in ts.keys():

--- a/pastas/recharge.py
+++ b/pastas/recharge.py
@@ -55,6 +55,7 @@ class RechargeBase:
     def __init__(self):
         self.snow = False
         self.nparam = 0
+        self.kwargs = {}
 
     @staticmethod
     def get_init_parameters(name="recharge"):
@@ -206,6 +207,9 @@ class FlexModel(RechargeBase):
             self.nparam += 1
         if self.snow:
             self.nparam += 2
+        self.kwargs['interception'] = interception
+        self.kwargs['snow'] = snow
+        self.kwargs['gw_uptake'] = gw_uptake
 
     def get_init_parameters(self, name="recharge"):
         parameters = DataFrame(

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1196,6 +1196,7 @@ class RechargeModel(StressModelBase):
             "rfunc": self.rfunc._name,
             "name": self.name,
             "recharge": self.recharge._name,
+            "recharge_kwargs": self.recharge.kwargs,
             "cutoff": self.rfunc.cutoff,
             "temp": self.temp.to_dict() if self.temp else None
         }
@@ -1464,7 +1465,8 @@ class ChangeModel(StressModelBase):
         h = omega * h1 + (1 - omega) * h2
 
         return h
-    
+
+
 class ReservoirModel(StressModelBase):
     """Time series model consisting of a single reservoir with two stresses.
     The first stress causes the head to go up and the second stress causes 
@@ -1500,12 +1502,12 @@ class ReservoirModel(StressModelBase):
     """
     _name = "ReservoirModel"
 
-    def __init__(self, stress, reservoir, name, meanhead, 
-                 settings=("prec", "evap"), metadata=(None, None), 
+    def __init__(self, stress, reservoir, name, meanhead,
+                 settings=("prec", "evap"), metadata=(None, None),
                  meanstress=None):
         # Set resevoir object
         self.reservoir = reservoir(meanhead)
-        
+
         # Code below is copied from StressModel2 and may not be optimal
         # Check the series, then determine tmin and tmax
         stress0 = TimeSeries(stress[0], settings=settings[0],
@@ -1560,7 +1562,7 @@ class ReservoirModel(StressModelBase):
         pandas.Series
             The simulated head contribution.
         """
-        
+
         stress = self.get_stress(tmin=tmin, tmax=tmax, freq=freq)
         h = Series(data=self.reservoir.simulate(stress[0], stress[1], p),
                    index=stress[0].index, name=self.name, fastpath=True)
@@ -1587,7 +1589,7 @@ class ReservoirModel(StressModelBase):
             StressModel object.
         """
         pass
-    
+
     def _get_block(self, p, dt, tmin, tmax):
         """Internal method to get the block-response function.
         Cannot be used (yet?) since there is no block response"""


### PR DESCRIPTION
# Short Description
This fix makes it possible to save the interception, snow and gw_uptake in a pas-file

# Checklist before PR can be merged:
- [ ] closes issue #xxxx
- [ ] is documented
- [ ] PEP8 compliant code
- [ ] tests added / passed
- [ ] Example Notebook (for new features)
- [ ] API changes documented in Release Notes
