### PR TITLE
fix #380, modification for #177

### DIFF
--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1,12 +1,16 @@
 # coding=utf-8
 """This module contains all the response functions available in Pastas."""
 
+from logging import getLogger
+
 import numpy as np
 from pandas import DataFrame
 from scipy.integrate import quad
 from scipy.special import (erfc, erfcinv, exp1, gammainc, gammaincinv, k0, k1,
                            lambertw)
 from scipy.interpolate import interp1d
+
+logger = getLogger(__name__)
 
 __all__ = ["Gamma", "Exponential", "Hantush", "Polder", "FourParam",
            "DoubleExponential", "One", "Edelman", "HantushWellModel",
@@ -324,8 +328,18 @@ class HantushWellModel(RfuncBase):
         parameters.loc[name + '_b'] = (binit, bmin, bmax, True, name)
         return parameters
 
+    @staticmethod
+    def _get_distance_from_params(p):
+        if len(p) == 3:
+            r = 1.0
+            logger.info("No distance passed to HantushWellModel, "
+                        "assuming r=1.0.")
+        else:
+            r = p[3]
+        return r
+
     def get_tmax(self, p, cutoff=None):
-        r = 1.0 if len(p) == 3 else p[3]
+        r = self._get_distance_from_params(p)
         # approximate formula for tmax
         if cutoff is None:
             cutoff = self.cutoff
@@ -337,14 +351,13 @@ class HantushWellModel(RfuncBase):
         else:
             return lambertw(1 / ((1 - cutoff) * k0rho)).real * cS
 
-    @staticmethod
-    def gain(p):
-        r = 1.0 if len(p) == 3 else p[3]
+    def gain(self, p):
+        r = self._get_distance_from_params(p)
         rho = np.sqrt(4 * r ** 2 * p[2])
         return p[0] * k0(rho)
 
     def step(self, p, dt=1, cutoff=None, maxtmax=None):
-        r = 1.0 if len(p) == 3 else p[3]
+        r = self._get_distance_from_params(p)
         cS = p[1]
         rho = np.sqrt(4 * r ** 2 * p[2])
         k0rho = k0(rho)
@@ -394,11 +407,11 @@ class HantushWellModel(RfuncBase):
             uncertainty of parameters A and b.
         """
         var_gain = (
-                (k0(2 * np.sqrt(r ** 2 * b))) ** 2 * var_A +
-                (-A * r * k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(
-                    b)) ** 2 * var_b -
-                2 * A * r * k0(2 * np.sqrt(r ** 2 * b)) *
-                k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(b) * cov_Ab
+            (k0(2 * np.sqrt(r ** 2 * b))) ** 2 * var_A +
+            (-A * r * k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(
+                b)) ** 2 * var_b -
+            2 * A * r * k0(2 * np.sqrt(r ** 2 * b)) *
+            k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(b) * cov_Ab
         )
         return var_gain
 
@@ -965,8 +978,8 @@ class Kraijenhoff(RfuncBase):
         h = 0
         for n in range(self.n_terms):
             h += (-1) ** n / (2 * n + 1) ** 3 * \
-                 np.cos((2 * n + 1) * np.pi * p[2]) * \
-                 np.exp(-(2 * n + 1) ** 2 * t / p[1])
+                np.cos((2 * n + 1) * np.pi * p[2]) * \
+                np.exp(-(2 * n + 1) ** 2 * t / p[1])
         s = p[0] * (1 - (8 / (np.pi ** 3 * (1 / 4 - p[2] ** 2)) * h))
         return s
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -19,6 +19,7 @@ from logging import getLogger
 import numpy as np
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat, date_range
 from scipy.signal import fftconvolve
+from scipy import __version__ as scipyversion
 
 from .decorators import njit, set_parameter
 from .recharge import Linear
@@ -686,9 +687,13 @@ class WellModel(StressModelBase):
             raise NotImplementedError("WellModel only supports the rfunc "
                                       "HantushWellModel!")
 
-        logger.warning("It is recommended to use LmfitSolve as the solver "
-                       "when implementing WellModel. See "
-                       "https://github.com/pastas/pastas/issues/177.")
+        # Check if scipy < 1.8
+        from distutils.version import StrictVersion
+        if StrictVersion(scipyversion) < StrictVersion("1.8.0"):
+            logger.warning(
+                "It is recommended to use LmfitSolve as the solver "
+                "or update to scipy>=1.8.0 when implementing WellModel."
+                " See https://github.com/pastas/pastas/issues/177.")
 
         # sort wells by distance
         self.sort_wells = sort_wells


### PR DESCRIPTION
- add logger info message when HantushWellModel is assuming r=1.0
- print warning when using WellModel if scipy version < 1.8

# Short Description
- Inform user when HantushWellModel is using r=1.0 (this occasionally happens when calling methods on model object that take parameters from `ml.parameters`), and might be relevant information for the user. See #380.
- Improve WellModel warning message. Given fix for #177 in scipy 1.8, no longer warn user when scipy >= 1.8. Otherwise recommend LmFitSolve or updating scipy.

# Checklist before PR can be merged:
- [x] closes issue #380, addresses #177
- [ ] ~is documented~
- [x] PEP8 compliant code
- [ ] ~tests added / passed~
- [ ] ~Example Notebook (for new features)~
- [x] API changes documented in Release Notes
