### PR TITLE
Add SolveTimer()

### DIFF
--- a/pastas/modelplots.py
+++ b/pastas/modelplots.py
@@ -695,6 +695,8 @@ class Plotting:
         tmin : str or pandas.Timestamp, optional
         tmax : str or pandas.Timestamp, optional
         figsize : tuple, optional
+        stacklegend : bool, optional
+            Add legend to the stacked plot.
 
         Returns
         -------

--- a/pastas/modelplots.py
+++ b/pastas/modelplots.py
@@ -682,7 +682,8 @@ class Plotting:
         return ax
 
     @model_tmin_tmax
-    def stacked_results(self, tmin=None, tmax=None, figsize=(10, 8), **kwargs):
+    def stacked_results(self, tmin=None, tmax=None, figsize=(10, 8),
+                        stacklegend=False, **kwargs):
         """Create a results plot, similar to `ml.plots.results()`, in which the
         individual contributions of stresses (in stressmodels with multiple
         stresses) are stacked.
@@ -742,7 +743,8 @@ class Plotting:
                 vstack = concat(contrib, axis=1, sort=False)
                 names = [c[0] for c in contributions]  # get names
                 ax.stackplot(vstack.index, vstack.values.T, labels=names)
-                ax.legend(loc="best", ncol=5, fontsize=8)
+                if stacklegend:
+                    ax.legend(loc="best", ncol=5, fontsize=8)
 
                 # y-scale does not show 0
                 ylower, yupper = ax.get_ylim()

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -921,6 +921,8 @@ class WellModel(StressModelBase):
             raise AttributeError("Model not optimized! Run solve() first!")
         if self.rfunc._name != "HantushWellModel":
             raise ValueError("Response function must be HantushWellModel!")
+        if model.fit.pcov.isna().all(axis=None):
+            model.logger.warn("Covariance matrix contains only NaNs!")
 
         # get parameters and (co)variances
         A = model.parameters.loc[self.name + "_A", "optimal"]

--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -1,0 +1,37 @@
+try:
+    from tqdm.auto import tqdm
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("SolveTimer requires 'tqdm' to be installed.")
+
+
+class SolveTimer(tqdm):
+    """Progress indicator for model optimization.
+
+    Usage
+    ----- 
+    Print timer and number of iterations in console while running
+    `ml.solve()`::
+
+    >>> with SolveTimer() as t:
+            ml.solve(callback=t.update)
+
+    This prints the following to the console, for example::
+
+        Optimization progress: 73it [00:01, 67.68it/s]
+
+    Note
+    ----
+    If the logger is also printing messages to the console the timer will not
+    be updated quite as nicely.
+    """
+
+    def __init__(self, *args, **kwargs):
+        if "total" not in kwargs:
+            kwargs['total'] = None
+        if "desc" not in kwargs:
+            kwargs["desc"] = "Optimization progress"
+        super(SolveTimer, self).__init__(*args, **kwargs)
+
+    def update(self, _, n=1):
+        displayed = super(SolveTimer, self).update(n)
+        return displayed

--- a/pastas/utils.py
+++ b/pastas/utils.py
@@ -442,7 +442,7 @@ def datenum_to_datetime(datenum):
     """
     days = datenum % 1.
     return datetime.fromordinal(int(datenum)) \
-           + timedelta(days=days) - timedelta(days=366)
+        + timedelta(days=days) - timedelta(days=366)
 
 
 def datetime2matlab(tindex):


### PR DESCRIPTION
# Short Description
Add a timer for model optimization. I was running into some _extremely_ slow running models somewhere within my 400 model dataset, and found this useful in diagnosing the issue, by printing the model name in my loop and then showing some record of elapsed time and no. of iterations. 

It does require `tqdm` to be installed, so I put it into a different file that is not imported by default. Due to the optional nature of the dependency I haven't added any examples or tests.

# Usage:
```python
from pastas.timer import SolveTimer

with SolveTimer() as t:
    ml.solve(callback=t.timer)
```
This prints the following to the console:
```
Optimization progress: 73it [00:01, 67.68it/s]
```

# Checklist before PR can be merged:
- [ ] ~closes issue #xxxx~
- [x] is documented
- [x] PEP8 compliant code
- [ ] ~tests added / passed~
- [ ] ~Example Notebook (for new features)~
- [ ] ~API changes documented in Release Notes~
