### PR TITLE
304 enhancement check data types in load model method

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1828,6 +1828,7 @@ class Model:
         --------
         :mod:`pastas.io.dump`
         """
+        self.name = validate_name(self.name, raise_error=True)
 
         # Get dicts for all data sources
         data = self.to_dict(series=series)

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -142,6 +142,7 @@ class StressModelBase:
         data = []
 
         for stress in self.stress:
+            stress.name = validate_name(stress.name, raise_error=True)
             data.append(stress.to_dict(series=series))
 
         return data

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -179,7 +179,7 @@ class StressModelBase:
         """
         data = {
             "stressmodel": self._name,
-            "name": self.name,
+            "name": validate_name(self.name, raise_error=True),
             "stress": self.dump_stress(series)
         }
         return data
@@ -1531,7 +1531,7 @@ class ChangeModel(StressModelBase):
 
 class ReservoirModel(StressModelBase):
     """Time series model consisting of a single reservoir with two stresses.
-    The first stress causes the head to go up and the second stress causes 
+    The first stress causes the head to go up and the second stress causes
     the head to go down.
 
     Parameters

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -5,7 +5,7 @@ from pandas.tseries.frequencies import to_offset
 
 from .rcparams import rcParams
 from .utils import (_get_dt, _get_stress_dt, _get_time_offset,
-                    timestep_weighted_resample)
+                    timestep_weighted_resample, validate_name)
 
 logger = getLogger(__name__)
 
@@ -108,8 +108,8 @@ class TimeSeries:
         # Use user provided name or set from series
         if name is None:
             name = series.name
-        self.name = name
-        self._series_original.name = name
+        self.name = validate_name(name)
+        self._series_original.name = validate_name(name)
 
         if metadata is not None:
             self.metadata.update(metadata)

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -7,6 +7,7 @@ import numpy as np
 from pandas import DataFrame
 
 from .decorators import set_parameter
+from .utils import validate_name
 
 
 class ThresholdTransform:
@@ -42,7 +43,7 @@ class ThresholdTransform:
         self.value = value
         self.vmin = vmin
         self.vmax = vmax
-        self.name = name
+        self.name = validate_name(name)
         self.nparam = nparam
         self.parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])

--- a/pastas/utils.py
+++ b/pastas/utils.py
@@ -1,6 +1,7 @@
 """This module contains utility functions for working with Pastas models."""
 
 import logging
+from logging import handlers
 from platform import platform
 from datetime import datetime, timedelta
 
@@ -562,9 +563,9 @@ def add_file_handlers(logger=None, filenames=('info.log', 'errors.log'),
 
     # create file handlers, set the level & formatter, and add it to the logger
     for filename, level in zip(filenames, levels):
-        fh = logging.handlers.RotatingFileHandler(filename, maxBytes=maxBytes,
-                                                  backupCount=backupCount,
-                                                  encoding=encoding)
+        fh = handlers.RotatingFileHandler(filename, maxBytes=maxBytes,
+                                          backupCount=backupCount,
+                                          encoding=encoding)
         fh.setLevel(level)
         fh.setFormatter(formatter)
         logger.addHandler(fh)
@@ -583,7 +584,7 @@ def remove_file_handlers(logger=None):
     if logger is None:
         logger = logging.getLogger('pastas')
     for handler in logger.handlers:
-        if isinstance(handler, logging.handlers.RotatingFileHandler):
+        if isinstance(handler, handlers.RotatingFileHandler):
             logger.removeHandler(handler)
 
 

--- a/pastas/utils.py
+++ b/pastas/utils.py
@@ -563,8 +563,8 @@ def add_file_handlers(logger=None, filenames=('info.log', 'errors.log'),
     # create file handlers, set the level & formatter, and add it to the logger
     for filename, level in zip(filenames, levels):
         fh = logging.handlers.RotatingFileHandler(filename, maxBytes=maxBytes,
-                                          backupCount=backupCount,
-                                          encoding=encoding)
+                                                  backupCount=backupCount,
+                                                  encoding=encoding)
         fh.setLevel(level)
         fh.setFormatter(formatter)
         logger.addHandler(fh)
@@ -604,7 +604,7 @@ def validate_name(name, raise_error=False):
         Unchanged name string
 
     """
-    ilchar = ["/", "\\", " ", ".", "'", '"', "`",]
+    ilchar = ["/", "\\", " ", ".", "'", '"', "`"]
     if 'windows' in platform().lower():
         ilchar += ["#", "%", "&", "@", "{", "}", "|", "$",
                    "*", "<", ">", "?", "!", ":", "=", "+"]


### PR DESCRIPTION
# Short Description
This pull request updates the `validate_name` function in utils. The list of illegal characters are expanded with a list from [Michigan Technological University](https://www.mtu.edu/umc/services/websites/writing/characters-avoid/). However, the OS of the user is also checked such that Linux and MacOS users are not punished for Windows' sins (more illegal characters than need be). 

When a name contains an illegal character an warning is printed when creating a (stress)model with this name. When writing to  a dict of .pas file an Exception error is raised instead.
# Checklist before PR can be merged:
- [x] closes issue #304 
- [x] is documented
- [x] PEP8 compliant code
- [x] API changes documented in Release Notes
