### PR TITLE
Add publications and references list

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,8 @@
 # Required
 version: 2
 
+
+
 build:
   os: ubuntu-22.04
   tools:
@@ -19,10 +21,12 @@ sphinx:
 #  configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats:
+  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
+  system_packages: true
   install:
     - requirements: requirements.rtd.txt
     - requirements: requirements.ci.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,8 +21,9 @@ sphinx:
 #  configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - epub
+#formats:
+#  - epub
+#  - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,6 +17,7 @@ import sys
 from datetime import date
 
 import requests
+import re
 
 year = date.today().strftime("%Y")
 
@@ -179,7 +180,9 @@ params = {"format": "bibtex",
 
 r = requests.get(url=url, params=params)
 with open("publications.bib", mode="w") as file:
-    file.write(r.text)
+    # Replace citation key to prevent duplicate labels and article now shown
+    text = re.sub("@[a-z]*{", "@{A_", r.text)
+    file.write(text)
 
 # Add some settings for bibtex
 bibtex_bibfiles = ['references.bib', 'publications.bib']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,7 +181,7 @@ params = {"format": "bibtex",
 r = requests.get(url=url, params=params)
 with open("publications.bib", mode="w") as file:
     # Replace citation key to prevent duplicate labels and article now shown
-    text = re.sub("(?:@[a-z])*{", "{A_", r.text)
+    text = re.sub(r'(@([a-z]*){)', r'\1X_', r.text)
     file.write(text)
 
 # Add some settings for bibtex

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,7 +75,7 @@ author = u'R.A. Collenteur, M. Bakker, R. Calje, F. Schaars'
 # The version.
 version = __version__
 release = __version__
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'IPython.sphinxext.ipython_console_highlighting',  # lowercase didn't work
     'sphinx.ext.autosectionlabel',
-    'nbsphinx',
+    #'nbsphinx',
     'sphinx_gallery.load_style',
     'sphinxcontrib.bibtex',
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,7 +181,7 @@ params = {"format": "bibtex",
 r = requests.get(url=url, params=params)
 with open("publications.bib", mode="w") as file:
     # Replace citation key to prevent duplicate labels and article now shown
-    text = re.sub("@[a-z]*{", "@{A_", r.text)
+    text = re.sub("(?:@[a-z])*{", "{A_", r.text)
     file.write(text)
 
 # Add some settings for bibtex

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,9 +20,9 @@ import requests
 
 year = date.today().strftime("%Y")
 
-import matplotlib
+from matplotlib import use
 
-matplotlib.use('agg')
+use('agg')
 
 from pastas.version import __version__
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,7 +54,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'IPython.sphinxext.ipython_console_highlighting',  # lowercase didn't work
     'sphinx.ext.autosectionlabel',
-    #'nbsphinx',
+    'nbsphinx',
     'sphinx_gallery.load_style',
     'sphinxcontrib.bibtex',
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,9 @@
 import os
 import sys
 from datetime import date
+
+import requests
+
 year = date.today().strftime("%Y")
 
 import matplotlib
@@ -22,6 +25,13 @@ import matplotlib
 matplotlib.use('agg')
 
 from pastas.version import __version__
+
+from dataclasses import dataclass, field
+import sphinxcontrib.bibtex.plugin
+
+from sphinxcontrib.bibtex.style.referencing import BracketStyle
+from sphinxcontrib.bibtex.style.referencing.author_year \
+    import AuthorYearReferenceStyle
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -45,13 +55,12 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'nbsphinx',
     'sphinx_gallery.load_style',
+    'sphinxcontrib.bibtex',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 source_suffix = '.rst'
-
-# The encoding of source files.
 source_encoding = 'utf-8'
 
 # The master toctree document.
@@ -67,12 +76,6 @@ author = u'R.A. Collenteur, M. Bakker, R. Calje, F. Schaars'
 version = __version__
 release = __version__
 language = None
-
-# There are two options for replacing |today|: either, you set today to some
-# non-false value, then it is used:
-# today = ''
-# Else, today_fmt is used as the format for a strftime call.
-# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -110,14 +113,18 @@ todo_include_todos = False
 html_theme = "pydata_sphinx_theme"
 html_logo = "_static/logo.png"
 html_static_path = ['_static']
+html_short_title = "Pastas"
+html_favicon = "_static/favo.ico"
+html_css_files = ['css/custom.css']
+html_show_sphinx = True
+html_show_copyright = True
+htmlhelp_basename = 'Pastasdoc'  # Output file base name for HTML help builder.
+html_use_smartypants = True
 
 html_theme_options = {
     "github_url": "https://github.com/pastas/pastas",
     "use_edit_page_button": False
 }
-
-autosummary_generate = True
-numpydoc_show_class_members = False
 
 html_context = {
     "github_user": "pastas",
@@ -126,42 +133,57 @@ html_context = {
     "doc_path": "doc",
 }
 
-html_css_files = [
-    'css/custom.css',
-]
+autosummary_generate = True
+numpydoc_show_class_members = False
 
-# A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = "Pastas"
-html_favicon = "_static/favo.ico"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-html_use_smartypants = True
-
-# If false, no module index is generated.
-# html_domain_indices = True
-
-# If false, no index is generated.
-# html_use_index = True
-
-# If true, the index is split into individual pages for each letter.
-# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
 # html_show_sourcelink = True
 
-# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-html_show_sphinx = True
-# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-html_show_copyright = True
+# -- Generating references and publications lists -------------------------
 
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'Pastasdoc'
+# support Round brackets
+def bracket_style() -> BracketStyle:
+    return BracketStyle(left='(', right=')', )
+
+
+@dataclass
+class MyReferenceStyle(AuthorYearReferenceStyle):
+    bracket_parenthetical: BracketStyle = field(default_factory=bracket_style)
+    bracket_textual: BracketStyle = field(default_factory=bracket_style)
+    bracket_author: BracketStyle = field(default_factory=bracket_style)
+    bracket_label: BracketStyle = field(default_factory=bracket_style)
+    bracket_year: BracketStyle = field(default_factory=bracket_style)
+
+
+sphinxcontrib.bibtex.plugin.register_plugin(
+    'sphinxcontrib.bibtex.style.referencing',
+    'author_year_round', MyReferenceStyle)
+
+# Generate bibliography-files from Zotero library
+# Get a Bibtex reference file from the Zotero group for referencing
+url = "https://api.zotero.org/groups/4846685/collections/8UG7PVLY/items/"
+params = {"format": "bibtex",
+          "style": "apa",
+          "limit": 100}
+
+r = requests.get(url=url, params=params)
+with open("references.bib", mode="w") as file:
+    file.write(r.text)
+
+# Get a Bibtex reference file from the Zotero group for publications list
+url = "https://api.zotero.org/groups/4846685/collections/Q4F7R59G/items/"
+params = {"format": "bibtex",
+          "style": "apa",
+          "limit": 100}
+
+r = requests.get(url=url, params=params)
+with open("publications.bib", mode="w") as file:
+    file.write(r.text)
+
+# Add some settings for bibtex
+bibtex_bibfiles = ['references.bib', 'publications.bib']
+bibtex_reference_style = "author_year_round"
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/doc/examples/03_diagnostic_checking.ipynb
+++ b/doc/examples/03_diagnostic_checking.ipynb
@@ -477,7 +477,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/06_adding_trends.ipynb
+++ b/doc/examples/06_adding_trends.ipynb
@@ -261,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/07_non_linear_recharge.ipynb
+++ b/doc/examples/07_non_linear_recharge.ipynb
@@ -146,13 +146,6 @@
     "- The heads (`B32C0639001.csv`) are downloaded from https://www.dinoloket.nl/ \n",
     "- The precipitation and evapotranspiration (`rain_260.csv` and `evap_260.csv`) are downloaded from https://knmi.nl"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -171,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/10_multiple_wells.ipynb
+++ b/doc/examples/10_multiple_wells.ipynb
@@ -455,13 +455,6 @@
    "source": [
     "df.style.format(\"{:.4f}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -480,7 +473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   },
   "vscode": {
    "interpreter": {

--- a/doc/examples/11_sgi_example.ipynb
+++ b/doc/examples/11_sgi_example.ipynb
@@ -335,13 +335,6 @@
     "- The precipitation and evaporation time series are taken from the Dutch KNMI, meteorological station \"de Bilt\" (www.knmi.nl).\n",
     "- The groundwater level time series were downloaded from Dinoloket (www.dinoloket.nl)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -360,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/12_emcee_uncertainty.ipynb
+++ b/doc/examples/12_emcee_uncertainty.ipynb
@@ -29,7 +29,8 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "ps.set_log_level(\"ERROR\")"
+    "ps.set_log_level(\"ERROR\")\n",
+    "ps.show_versions(lmfit=True)"
    ]
   },
   {
@@ -78,9 +79,9 @@
    "outputs": [],
    "source": [
     "ml.set_parameter(\"noise_alpha\", vary=True)\n",
-    "#ml.set_parameter(\"constant_d\", vary=False)\n",
-    "ml.solve(tmin=\"2002\", noise=True, initial=False, fit_constant=False, solver=ps.LmfitSolve, \n",
-    "         method=\"emcee\", steps=200, burn=10, thin=5, is_weighted=True, nan_policy=\"omit\");"
+    "\n",
+    "ml.solve(tmin=\"2002\", noise=True, initial=False, fit_constant=True, solver=ps.LmfitSolve, \n",
+    "         method=\"emcee\", nwalkers=10, steps=20, burn=2, thin=2, is_weighted=True, nan_policy=\"omit\");"
    ]
   },
   {
@@ -155,8 +156,7 @@
     "inds = np.random.randint(len(ml.fit.result.flatchain), size=100)\n",
     "for ind in inds:\n",
     "    params = ml.fit.result.flatchain.iloc[ind].values\n",
-    "    ml.simulate(params).plot(c=\"k\", alpha=0.1)\n",
-    "plt.ylim(27,30)"
+    "    ml.simulate(params).plot(c=\"k\", alpha=0.1, zorder=0)"
    ]
   }
  ],
@@ -176,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/13_timestep_analysis.ipynb
+++ b/doc/examples/13_timestep_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "929a2c26",
+   "id": "18b97945",
    "metadata": {},
    "source": [
     "# Reducing Autocorrelation\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "610c5ec2",
+   "id": "ac672a61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7cc7c49",
+   "id": "c6c96b0b",
    "metadata": {},
    "source": [
     "## 1. Read Data and plot autocorrelation\n",
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f00c9ef7",
+   "id": "ca088547",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a755acfa",
+   "id": "4941b0ba",
    "metadata": {},
    "source": [
     "## 2. Run models with AR(1) noise model\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f0f9525",
+   "id": "4411f0e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b7d7d76",
+   "id": "63441c80",
    "metadata": {},
    "source": [
     "## 3. Run models with ARMA(1,1) noise model\n",
@@ -133,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "211f4cc8",
+   "id": "45df64c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74666d35",
+   "id": "472746da",
    "metadata": {},
    "source": [
     "## 4. Plot and compare the the results\n",
@@ -174,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ccf61a0",
+   "id": "d163b7fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c78b4cbb",
+   "id": "29f32a53",
    "metadata": {},
    "source": [
     "## 5. Consistency of parameter estimates\n",
@@ -228,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a87a7b0",
+   "id": "cb579d8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77b34918",
+   "id": "352ec52d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "370210af",
+   "id": "37bfbe01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef953542",
+   "id": "87f9dbcb",
    "metadata": {},
    "source": [
     "The plot above shows the estimated optimal parameters and the 95% confidence intervals of the parameters. While most of the optimal parameter are relatively stable between calibrations, some parameters show larger variations. For the linear model these are, for example, $a$ and $n$, while for the non-linear model these are $k_s$ and $\\gamma$. The values of these parameters seem correlated, and it might thus be difficult to estimate the individual parameter values.\n",
@@ -327,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b26c33a9",
+   "id": "c5b92cf5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bf1b719",
+   "id": "768bbea9",
    "metadata": {},
    "source": [
     "## Data sources\n",
@@ -398,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/13_timestep_analysis.ipynb
+++ b/doc/examples/13_timestep_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "18b97945",
+   "id": "5c22b882",
    "metadata": {},
    "source": [
     "# Reducing Autocorrelation\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac672a61",
+   "id": "6e4f46b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,12 +34,12 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True, lmfit=True)"
+    "ps.show_versions(numba=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c6c96b0b",
+   "id": "6e493eed",
    "metadata": {},
    "source": [
     "## 1. Read Data and plot autocorrelation\n",
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca088547",
+   "id": "0f8c9515",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4941b0ba",
+   "id": "21a2bcde",
    "metadata": {},
    "source": [
     "## 2. Run models with AR(1) noise model\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4411f0e2",
+   "id": "f73db566",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,16 +90,15 @@
     "# Model settings\n",
     "tmin = \"2007-01-01\"\n",
     "tmax = \"2016-12-31\"\n",
-    "solver = ps.LmfitSolve\n",
     "\n",
     "# The two models we compare here\n",
     "config = {\n",
-    "    \"Linear\": [ps.FourParam, ps.rch.Linear()],\n",
+    "    \"Linear\": [ps.Gamma, ps.rch.Linear()],\n",
     "    \"Nonlinear\": [ps.Exponential, ps.rch.FlexModel()],\n",
     "}\n",
     "\n",
     "for name, [rfunc, rch] in config.items():\n",
-    "    for dt in range(1, dts, 2):\n",
+    "    for dt in range(1, dts, 4):\n",
     "        # Create the basic Pastas model\n",
     "        ml_name = f\"{name}_{dt}\"\n",
     "        ml = ps.Model(head.iloc[::dt], name=ml_name)\n",
@@ -116,14 +115,13 @@
     "            ml.set_parameter(\"constant_d\", initial=262)\n",
     "\n",
     "        # Solve the model\n",
-    "        ml.solve(tmin=tmin, tmax=tmax, report=False, solver=solver, \n",
-    "                 method=\"least_squares\")\n",
+    "        ml.solve(tmin=tmin, tmax=tmax, report=False)\n",
     "        mls_ar[ml_name] = ml"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "63441c80",
+   "id": "64e7d34d",
    "metadata": {},
    "source": [
     "## 3. Run models with ARMA(1,1) noise model\n",
@@ -133,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45df64c5",
+   "id": "90223501",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,14 +145,13 @@
     "    ml.add_noisemodel(ps.ArmaModel())\n",
     "\n",
     "    # Solve the model\n",
-    "    ml.solve(tmin=tmin, tmax=tmax, report=False, solver=solver, \n",
-    "             method=\"least_squares\")\n",
+    "    ml.solve(tmin=tmin, tmax=tmax, report=False)\n",
     "    mls_arma[ml_name] = ml"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "472746da",
+   "id": "8c38c159",
    "metadata": {},
    "source": [
     "## 4. Plot and compare the the results\n",
@@ -174,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d163b7fd",
+   "id": "7cbe06e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29f32a53",
+   "id": "3549e516",
    "metadata": {},
    "source": [
     "## 5. Consistency of parameter estimates\n",
@@ -228,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb579d8f",
+   "id": "1cc663f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +233,7 @@
     "dt = 10  # Select the time interval between GWL observations\n",
     "\n",
     "for name, [rfunc, rch] in config.items():\n",
-    "    for start in range(0, dt, 2):\n",
+    "    for start in range(0, dt, 4):\n",
     "        ml_name = f\"{name}_{start+1}\"\n",
     "        ml = ps.Model(head.iloc[start::dt], name=ml_name)\n",
     "\n",
@@ -251,8 +248,7 @@
     "\n",
     "        # Solve the model\n",
     "        ml.add_noisemodel(ps.ArmaModel())\n",
-    "        ml.solve(tmin=tmin, tmax=tmax, report=False, solver=solver, \n",
-    "                 method=\"least_squares\")\n",
+    "        ml.solve(tmin=tmin, tmax=tmax, report=False)\n",
     "\n",
     "        mls[ml_name] = ml"
    ]
@@ -260,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "352ec52d",
+   "id": "da160d75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37bfbe01",
+   "id": "43ca0d48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87f9dbcb",
+   "id": "7a42b6a9",
    "metadata": {},
    "source": [
     "The plot above shows the estimated optimal parameters and the 95% confidence intervals of the parameters. While most of the optimal parameter are relatively stable between calibrations, some parameters show larger variations. For the linear model these are, for example, $a$ and $n$, while for the non-linear model these are $k_s$ and $\\gamma$. The values of these parameters seem correlated, and it might thus be difficult to estimate the individual parameter values.\n",
@@ -327,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5b92cf5",
+   "id": "beee42ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +363,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "768bbea9",
+   "id": "cf9934d5",
    "metadata": {},
    "source": [
     "## Data sources\n",

--- a/doc/examples/14_recharge_estimation.ipynb
+++ b/doc/examples/14_recharge_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dca9bbba",
+   "id": "076e9469",
    "metadata": {},
    "source": [
     "# Estimating recharge\n",
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c4ec0f8",
+   "id": "ba7ac2c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e87359e4",
+   "id": "ab4c62df",
    "metadata": {},
    "source": [
     "## 1. Load and visualize the input data\n",
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa57f18f",
+   "id": "00d28e55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4c37a76",
+   "id": "8ca17880",
    "metadata": {},
    "source": [
     "## 2. Creating and calibrating Pastas models\n",
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "227e3363",
+   "id": "e71d54ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "751a3b22",
+   "id": "b65d4940",
    "metadata": {},
    "source": [
     "## 3. Check for autocorrelation\n",
@@ -133,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1736fa5b",
+   "id": "3eae8f12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eee32ea",
+   "id": "5e99711b",
    "metadata": {},
    "source": [
     "## 4. Compute confidence intervals\n",
@@ -164,11 +164,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "764d2f4b",
+   "id": "f3777754",
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = int(1e4)  # number of monte carlo runs\n",
+    "n = int(1e2)  # number of monte carlo runs, set very low here for ReadTheDocs\n",
     "alpha = 0.05  # 95% confidence interval\n",
     "q = [alpha / 2, 1 - alpha / 2]\n",
     "\n",
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65851c46",
+   "id": "5cb2fb28",
    "metadata": {},
    "source": [
     "## 5. Visualize the results\n",
@@ -217,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ac68fe9",
+   "id": "47a83912",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5a5c368",
+   "id": "6a16f027",
    "metadata": {},
    "source": [
     "## 6. Plot the annual recharge rates\n",
@@ -277,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84947c82",
+   "id": "6fb15d09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efbb9607",
+   "id": "85b87bd7",
    "metadata": {},
    "source": [
     "## 7. Plot the step and block response functions\n",
@@ -301,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec66fd7d",
+   "id": "3d988776",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32e2127b",
+   "id": "18256fa9",
    "metadata": {},
    "source": [
     "## 8. Compute the goodness-of-fit for groundwater level simulation\n",
@@ -332,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4340b5db",
+   "id": "8c43e200",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ca39891",
+   "id": "5afa23ec",
    "metadata": {},
    "source": [
     "## Data sources:\n",
@@ -384,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/examples/15_uncertainty.ipynb
+++ b/doc/examples/15_uncertainty.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0b396ae5",
+   "id": "43403682",
    "metadata": {},
    "source": [
     "# Uncertainty quantification\n",
@@ -23,7 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff7a826d",
+   "id": "f28d9ef8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73c48782",
+   "id": "a2d7c310",
    "metadata": {},
    "source": [
     "## Create a model\n",
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77ba7a88",
+   "id": "b940701b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6913529b",
+   "id": "454edf41",
    "metadata": {},
    "source": [
     "## Diagnostic Checks\n",
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75cd6a5f",
+   "id": "563e3a68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f0341d4",
+   "id": "79c871ec",
    "metadata": {},
    "source": [
     "## Confidence intervals\n",
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d60d9f94",
+   "id": "093220bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "436a7029",
+   "id": "7b30158a",
    "metadata": {},
    "source": [
     "## Prediction interval"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "484e013e",
+   "id": "47839485",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdc2d08d",
+   "id": "37b08470",
    "metadata": {},
    "source": [
     "## Uncertainty of step response "
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bbeffab",
+   "id": "a8c72188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "933f046d",
+   "id": "6dbb6348",
    "metadata": {},
    "source": [
     "## Uncertainty of block response"
@@ -170,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1003124",
+   "id": "7ff6ba90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "001df91f",
+   "id": "18d544b2",
    "metadata": {},
    "source": [
     "## Uncertainty of the contributions"
@@ -191,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7edb337a",
+   "id": "83829142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fc264ac",
+   "id": "41ef8398",
    "metadata": {},
    "source": [
     "## Custom Confidence intervals\n",
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20ba64a2",
+   "id": "8f7ad6ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e7497ce",
+   "id": "fba72484",
    "metadata": {},
    "source": [
     "## Uncertainty of the NSE\n",
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b095b82b",
+   "id": "b4b0990e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -28,4 +28,6 @@ ask you to cite the Pastas article published in Groundwater journal as follows:
     Development <developers/index>
     API Docs <api/index>
     Release Notes <releases/index>
+    Publications <publications>
+    References <references>
 

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -3,10 +3,18 @@ Publications
 
 This page provides an overview of the publications that use Pastas in their work. The list is generated from the public
 Zotero library with the references. If you have used Pastas in your work, please add the reference to the
-`Zotero library <https://www.zotero.org/groups/4846685/pastas>`_ (collection `Publications`) and it will show up here!
+`Zotero library <https://www.zotero.org/groups/4846685/pastas>`_ (collection `Publications`) and it will show up here
+automatically (after next commit/release) !
 
 Peer-reviewed publications
 --------------------------
 
 .. bibliography:: publications.bib
+    :list: enumerated
     :all:
+
+2021
+----
+.. bibliography:: publications.bib
+    :list: enumerated
+    :filter: year == "2021"

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -9,12 +9,33 @@ automatically (after next commit/release) !
 Peer-reviewed publications
 --------------------------
 
+2022
+****
 .. bibliography:: publications.bib
     :list: enumerated
-    :all:
+    :filter: year == "2022"
 
 2021
-----
+****
 .. bibliography:: publications.bib
     :list: enumerated
     :filter: year == "2021"
+
+2020
+****
+.. bibliography:: publications.bib
+    :list: enumerated
+    :filter: year == "2020"
+
+2019
+****
+.. bibliography:: publications.bib
+    :list: enumerated
+    :filter: year == "2019"
+
+
+Academic Theses
+---------------
+
+Here the PhD., MSc, and BSc. thesis are to be added in the future. For now we refer to the
+[GitHub repo](https://github.com/pastas/pastas_research)

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -1,13 +1,21 @@
 Publications
 ============
 
-This page provides an overview of the publications that use Pastas in their work. The list is generated from the public
+This page provides an overview of the peer-reviewed publications that used Pastas. The list is generated from the public
 Zotero library with the references. If you have used Pastas in your work, please add the reference to the
 `Zotero library <https://www.zotero.org/groups/4846685/pastas>`_ (collection `Publications`) and it will show up here
-automatically (after next commit/release) !
+automatically (after next commit/release). Pastas has also been used in a number of PhD, MSc, and BSc theses and
+a large number of non-published reports, partly listed in a `GitHub repo here <https://github
+.com/pastas/pastas_research>`_.
 
 Peer-reviewed publications
 --------------------------
+
+2023
+****
+.. bibliography:: publications.bib
+    :list: bullet
+    :filter: year == "2023"
 
 2022
 ****
@@ -32,10 +40,3 @@ Peer-reviewed publications
 .. bibliography:: publications.bib
     :list: bullet
     :filter: year == "2019"
-
-
-Academic Theses
----------------
-
-Here the PhD., MSc, and BSc. thesis are to be added in the future. For now we refer to the
-[GitHub repo](https://github.com/pastas/pastas_research)

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -12,24 +12,31 @@ Peer-reviewed publications
 2022
 ****
 .. bibliography:: publications.bib
+    :labelprefix: A
+    :keyprefix: a-
     :list: enumerated
     :filter: year == "2022"
 
 2021
 ****
 .. bibliography:: publications.bib
+    :labelprefix: A
+    :keyprefix: a-
     :list: enumerated
     :filter: year == "2021"
 
 2020
 ****
 .. bibliography:: publications.bib
+    :labelprefix: A
+    :keyprefix: a-
     :list: enumerated
     :filter: year == "2020"
 
 2019
 ****
 .. bibliography:: publications.bib
+    :keyprefix: a-
     :list: enumerated
     :filter: year == "2019"
 

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -22,7 +22,7 @@ Peer-reviewed publications
 .. bibliography:: publications.bib
     :labelprefix: A
     :keyprefix: a-
-    :list: enumerated
+    :list: bullet
     :filter: year == "2021"
 
 2020
@@ -36,7 +36,7 @@ Peer-reviewed publications
 2019
 ****
 .. bibliography:: publications.bib
-    :keyprefix: a-
+    :all:
     :list: enumerated
     :filter: year == "2019"
 

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -12,32 +12,25 @@ Peer-reviewed publications
 2022
 ****
 .. bibliography:: publications.bib
-    :labelprefix: A
-    :keyprefix: a-
-    :list: enumerated
+    :list: bullet
     :filter: year == "2022"
 
 2021
 ****
 .. bibliography:: publications.bib
-    :labelprefix: A
-    :keyprefix: a-
     :list: bullet
     :filter: year == "2021"
 
 2020
 ****
 .. bibliography:: publications.bib
-    :labelprefix: A
-    :keyprefix: a-
-    :list: enumerated
+    :list: bullet
     :filter: year == "2020"
 
 2019
 ****
 .. bibliography:: publications.bib
-    :all:
-    :list: enumerated
+    :list: bullet
     :filter: year == "2019"
 
 

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -1,0 +1,12 @@
+Publications
+============
+
+This page provides an overview of the publications that use Pastas in their work. The list is generated from the public
+Zotero library with the references. If you have used Pastas in your work, please add the reference to the
+`Zotero library <https://www.zotero.org/groups/4846685/pastas>`_ (collection `Publications`) and it will show up here!
+
+Peer-reviewed publications
+--------------------------
+
+.. bibliography:: publications.bib
+    :all:

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,0 +1,12 @@
+References
+==========
+
+PyET is built on a lot of scientific literature. Here the references are listed for all the methods implemented in
+Pastas. This list is automatically generated from a public
+`Zotero library <https://www.zotero.org/groups/4846685/pastas>`_ (collection `References`). For a list of
+publications using Pastas we refer to the :ref:`Publications` page of this website.
+
+
+.. bibliography:: references.bib
+    :all:
+

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,7 +1,7 @@
 References
 ==========
 
-PyET is built on a lot of scientific literature. Here the references are listed for all the methods implemented in
+Pastas is built on a lot of scientific literature. Here the references are listed for all the methods implemented in
 Pastas. This list is automatically generated from a public
 `Zotero library <https://www.zotero.org/groups/4846685/pastas>`_ (collection `References`). For a list of
 publications using Pastas we refer to the :ref:`Publications` page of this website.

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -106,7 +106,7 @@ class NoiseModel(NoiseModelBase):
 
     Notes
     -----
-    Calculates the noise [1]_ according to:
+    Calculates the noise :cite:t:`von_asmuth_modeling_2005` according to:
 
     .. math::
 
@@ -121,19 +121,8 @@ class NoiseModel(NoiseModelBase):
     The units of the alpha parameter is always in days. The first value of
     the noise is the residual ($v(t=0=r(t=0)$). First weight is
     1 / sig_residuals (i.e., delt = infty). Normalization of weights as in
-    Von Asmuth and Bierkens (2005), optional.
+    :cite:t:`von_asmuth_modeling_2005`, optional.
 
-    Differences compared to NoiseModelOld:
-
-    1. First value is residual
-    2. First weight is 1 / sig_residuals (i.e., delt = infty)
-    3. Normalization of weights as in Von Asmuth and Bierkens (2005), optional
-
-    References
-    ----------
-    .. [1] von Asmuth, J. R., and M. F. P. Bierkens (2005), Modeling
-           irregularly spaced residual series as a continuous stochastic
-           process, Water Resour. Res., 41, W12404, doi:10.1029/2004WR003726.
     """
     _name = "NoiseModel"
 
@@ -188,7 +177,8 @@ class NoiseModel(NoiseModelBase):
 
         .. math:: w = 1 / sqrt((1 - exp(-2 \\Delta t / \\alpha)))
 
-        which are then normalized so that sum(w) = len(res)
+        which are then normalized so that sum(w) = len(res).
+Ò
         """
         alpha = p[0]
         # large for first measurement
@@ -204,7 +194,7 @@ class NoiseModel(NoiseModelBase):
 class ArmaModel(NoiseModelBase):
     """ARMA(1,1) Noise model to simulate the noise as defined in.
 
-    [collenteur_2020]_.
+    :cite:t:`collenteur_estimation_2021`.
 
     Notes
     -----
@@ -221,13 +211,6 @@ class ArmaModel(NoiseModelBase):
     This model has only been tested on regular time steps and should not be
     used for irregular time steps yet.
 
-    References
-    ----------
-    .. [collenteur_2020] Collenteur, R., Bakker, M., Klammler, G., and Birk,
-       S. (in review, 2020.) Estimating groundwater recharge from
-       groundwater levels using non-linear transfer function noise models
-       and comparison to lysimeter data, Hydrol. Earth Syst. Sci. Discuss.
-       https://doi.org/10.5194/hess-2020-392
     """
     _name = "ArmaModel"
 

--- a/pastas/recharge.py
+++ b/pastas/recharge.py
@@ -138,7 +138,8 @@ class Linear(RechargeBase):
 
 
 class FlexModel(RechargeBase):
-    """Recharge to the groundwater calculated according to [collenteur_2021]_.
+    """Recharge to the groundwater calculated according to
+    :cite:t:`collenteur_estimation_2021`.
 
     Parameters
     ----------
@@ -157,8 +158,8 @@ class FlexModel(RechargeBase):
     Notes
     -----
     For a detailed description of the recharge model and parameters we refer
-    to [collenteur_2021]_. The water balance for the unsaturated zone
-    reservoir is written as:
+    to :cite:t:`collenteur_estimation_2021`. The water balance for the
+    unsaturated zone reservoir is written as:
 
     .. math::
 
@@ -183,11 +184,6 @@ class FlexModel(RechargeBase):
 
     References
     ----------
-    .. [collenteur_2021] Collenteur, R. A., Bakker, M., Klammler, G., and
-       Birk, S.: Estimation of groundwater recharge from groundwater levels
-       using nonlinear transfer function noise models and comparison to
-       lysimeter data, Hydrol. Earth Syst. Sci., 25, 2931–2949,
-       https://doi.org/10.5194/hess-25-2931-2021, 2021.
 
     .. [kavetski_2007] Kavetski, D. and Kuczera, G. (2007). Model smoothing
        strategies to remove microscale discontinuities and  spurious

--- a/pastas/recharge.py
+++ b/pastas/recharge.py
@@ -81,7 +81,8 @@ class RechargeBase:
 
 
 class Linear(RechargeBase):
-    """Linear model for precipitation excess according to [asmuth_2002]_.
+    """Linear model for precipitation excess according to
+    :cite:t:`von_asmuth_transfer_2002`.
 
     Notes
     -----
@@ -89,12 +90,6 @@ class Linear(RechargeBase):
 
     .. math::
         R = P - f * E
-
-    References
-    ----------
-    .. [asmuth_2002] von Asmuth, J., Bierkens, M., and Maas, K. (2002) Transfer
-       function-noise modeling in continuous time using predefined impulse
-       response functions, Water Resources Research, 38, 23–1–23–12.
 
     """
     _name = "Linear"
@@ -173,7 +168,8 @@ class FlexModel(RechargeBase):
 
     If snow=True, a snow reservoir is added on top. For a detailed
     description of the degree-day snow model and parameters we refer to
-    [kavetski_2007]_. The water balance for the snow reservoir is written as:
+    :cite:t:`kavetski_model_2007`. The water balance for the snow reservoir
+    is written as:
 
     .. math::
 
@@ -181,14 +177,6 @@ class FlexModel(RechargeBase):
 
     Note that the preferred unit of the precipitation and evaporation is
     mm/d and the temperature is degree celsius.
-
-    References
-    ----------
-
-    .. [kavetski_2007] Kavetski, D. and Kuczera, G. (2007). Model smoothing
-       strategies to remove microscale discontinuities and  spurious
-       secondary optima  in  objective  functions  in  hydrological
-       calibration. Water Resources Research, 43(3).
 
     """
     _name = "FlexModel"
@@ -516,12 +504,13 @@ class FlexModel(RechargeBase):
 
 
 class Berendrecht(RechargeBase):
-    """Recharge to the groundwater calculated according to [berendrecht_2006]_.
+    """Recharge to the groundwater calculated according to
+    :cite:t:`berendrecht_non-linear_2006`.
 
     Notes
     -----
     Note that the preferred unit of the precipitation and evaporation is
-    mm/d. The waterbalance for the unsaturated zone reservoir is written as:
+    mm/d. The water balance for the unsaturated zone reservoir is written as:
 
     .. math::
         \\frac{dS_e}{dt} = \\frac{1}{D_e}(f_iP - E_a - R)
@@ -533,12 +522,6 @@ class Berendrecht(RechargeBase):
 
     For a detailed description of the recharge model and parameters we refer
     to the original publication.
-
-    References
-    ----------
-    .. [berendrecht_2006] Berendrecht, W. L., Heemink, A. W., van Geer, F. C.,
-       and Gehrels, J. C. (2006) A non-linear state space approach to model
-       groundwater fluctuations, Advances in Water Resources, 29, 959–973.
 
     """
     _name = "Berendrecht"
@@ -635,7 +618,9 @@ class Berendrecht(RechargeBase):
 
 
 class Peterson(RechargeBase):
-    """Recharge to the groundwater calculated based on [peterson_2014]_.
+    """Recharge to the groundwater calculated based on
+    :cite:t:`peterson_nonlinear_2014`.
+
     The water balance for the unsaturated zone reservoir is written as:
 
     .. math::
@@ -664,11 +649,6 @@ class Peterson(RechargeBase):
 
     Note that the method currently uses forward Euler method to solve
     the ODE so significant water balance errors can occur.
-
-    References
-    ----------
-    .. [peterson_2014] Peterson, T.J. and Western A.W. (2014). Nonlinear
-    time-series modeling of unconfined groundwater head.
 
     """
     _name = "Peterson"

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -297,13 +297,8 @@ class HantushWellModel(RfuncBase):
 
     :math:`\\text{gain} = A K_0 \\left( 2r \\sqrt(b) \\right)`
 
-    The implementation used here is explained in  [veling_2010]_.
+    The implementation used here is explained in  :cite:t:`veling_hantush_2010`.
 
-    References
-    ----------
-
-    .. [veling_2010] Veling, E. J. M., & Maas, C. (2010). Hantush well function
-       revisited. Journal of hydrology, 393(3), 381-388.
     """
     _name = "HantushWellModel"
 
@@ -317,8 +312,8 @@ class HantushWellModel(RfuncBase):
 
     def get_init_parameters(self, name):
         if self.distances is None:
-            raise(Exception('distances is None. Set using method set_distances'
-                            'or use Hantush.'))
+            raise (Exception('distances is None. Set using method set_distances'
+                             'or use Hantush.'))
         parameters = DataFrame(
             columns=['initial', 'pmin', 'pmax', 'vary', 'name'])
         if self.up:
@@ -429,11 +424,11 @@ class HantushWellModel(RfuncBase):
         ps.WellModel.variance_gain
         """
         var_gain = (
-            (k0(2 * np.sqrt(r ** 2 * b))) ** 2 * var_A +
-            (-A * r * k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(
-                b)) ** 2 * var_b -
-            2 * A * r * k0(2 * np.sqrt(r ** 2 * b)) *
-            k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(b) * cov_Ab
+                (k0(2 * np.sqrt(r ** 2 * b))) ** 2 * var_A +
+                (-A * r * k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(
+                    b)) ** 2 * var_b -
+                2 * A * r * k0(2 * np.sqrt(r ** 2 * b)) *
+                k1(2 * np.sqrt(r ** 2 * b)) / np.sqrt(b) * cov_Ab
         )
         return var_gain
 
@@ -461,7 +456,7 @@ class Hantush(RfuncBase):
 
     where A, a, and b are parameters.
 
-    The implementation used here is explained in  [veling_2010]_.
+    The implementation used here is explained in  :cite:t:`veling_hantush_2010`.
 
     References
     ----------
@@ -526,8 +521,9 @@ class Polder(RfuncBase):
 
     Notes
     -----
-    The Polder function is explained in [polder]_. The impulse response
-    function may be written as:
+    The Polder function is explained in Eq. 123.32 in
+    :cite:t:`bruggeman_analytical_1999`. The impulse response function may be
+    written as:
 
     .. math:: \\theta(t) = \\exp(-\\sqrt(4b)) \\frac{A}{t^{-3/2}}
        \\exp(-t/a -b/t)
@@ -537,10 +533,6 @@ class Polder(RfuncBase):
 
     where :math:`\\lambda = \\sqrt{kDc}`
 
-    References
-    ----------
-    .. [polder] G.A. Bruggeman (1999). Analytical solutions of
-       geohydrological problems. Elsevier Science. Amsterdam, Eq. 123.32
     """
     _name = "Polder"
 
@@ -872,8 +864,8 @@ class Edelman(RfuncBase):
 
     Notes
     -----
-    The Edelman function is explained in [5]_. The impulse response function
-    may be written as:
+    The Edelman function is explained in :cite:t:`edelman_over_1947`. The
+    impulse response function may be written as:
 
     .. math:: \\text{unknown}
 
@@ -881,9 +873,6 @@ class Edelman(RfuncBase):
 
     .. math:: p[0] = \\beta = \\frac{\\sqrt{\\frac{4kD}{S}}}{x}
 
-    References
-    ----------
-    .. [5] http://grondwaterformules.nl/index.php/formules/waterloop/peilverandering
     """
     _name = "Edelman"
 
@@ -914,7 +903,7 @@ class Edelman(RfuncBase):
 
 
 class Kraijenhoff(RfuncBase):
-    """The response function of Kraijenhoff van de Leur (and Bruggeman 133.15)
+    """The response function of :cite:t:`van_de_leur_study_1958`.
 
     Parameters
     ----------
@@ -929,31 +918,24 @@ class Kraijenhoff(RfuncBase):
 
     Notes
     -----
-    The Kraijenhoff van de Leur function is explained in [Kraijenhoff]_.
-    The impulse response function may be written as:
+    The Kraijenhoff van de Leur function is explained in
+    :cite:t:`van_de_leur_study_1958`. The impulse response function may be
+    written as:
 
     .. math:: \\theta(t) = \\frac{4}{\pi S} \sum_{n=1,3,5...}^\infty \\frac{1}{n} e^{-n^2\\frac{t}{j}} \sin (\\frac{n\pi x}{L})
 
     The function describes the response of a domain between two drainage
-    channels. The function gives the same outcome as Bruggeman equation 133.15.
-    Bruggeman 133.15 is the response that is actually calculated with this
-    function. [Bruggeman]_
+    channels. The function gives the same outcome as equation 133.15 in
+    :cite:t:`bruggeman_analytical_1999`. This is the response that
+    is actually calculated with this function.
 
     The response function has three parameters: A, a and b.
     A is the gain (scaled),
-    a is the reservoir coefficient (j in [Kraijenhoff]_),
+    a is the reservoir coefficient (j in :cite:t:`van_de_leur_study_1958`),
     b is the location in the domain with the origin in the middle. This means
     that b=0 is in the middle and b=1/2 is at the drainage channel. At b=1/4
     the response function is most similar to the exponential response function.
 
-    References
-    ----------
-    .. [Kraijenhoff] Kraijenhoff van de Leur, D. A. (1958). A study of
-       non-steady groundwater flow with special reference to a reservoir
-       coefficient. De Ingenieur, 70(19), B87-B94. https://edepot.wur.nl/422032
-
-    .. [Bruggeman] G.A. Bruggeman (1999). Analytical solutions of
-       geohydrological problems. Elsevier Science. Amsterdam, Eq. 133.15
     """
     _name = "Kraijenhoff"
 
@@ -994,8 +976,8 @@ class Kraijenhoff(RfuncBase):
         h = 0
         for n in range(self.n_terms):
             h += (-1) ** n / (2 * n + 1) ** 3 * \
-                np.cos((2 * n + 1) * np.pi * p[2]) * \
-                np.exp(-(2 * n + 1) ** 2 * t / p[1])
+                 np.cos((2 * n + 1) * np.pi * p[2]) * \
+                 np.exp(-(2 * n + 1) ** 2 * t / p[1])
         s = p[0] * (1 - (8 / (np.pi ** 3 * (1 / 4 - p[2] ** 2)) * h))
         return s
 

--- a/pastas/solver.py
+++ b/pastas/solver.py
@@ -360,7 +360,7 @@ class LeastSquares(BaseSolver):
     _name = "LeastSquares"
 
     def __init__(self, ml, pcov=None, nfev=None, **kwargs):
-        """Solver based on Scipy's least_squares method [scipy_ref]_.
+        """Solver based on Scipy's least_squares method.
 
         Notes
         -----
@@ -374,9 +374,10 @@ class LeastSquares(BaseSolver):
 
         >>> ml.solve(solver=ps.LeastSquares)
 
-        References
-        ----------
-        .. [scipy_ref] https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html
+        Notes
+        -----
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html
+
         """
         BaseSolver.__init__(self, ml=ml, pcov=pcov, nfev=nfev, **kwargs)
 
@@ -469,14 +470,15 @@ class LmfitSolve(BaseSolver):
     _name = "LmfitSolve"
 
     def __init__(self, ml, pcov=None, nfev=None, **kwargs):
-        """Solving the model using the LmFit solver [LM]_.
+        """Solving the model using the LmFit solver.
 
          This is basically a wrapper around the scipy solvers, adding some
          cool functionality for boundary conditions.
 
-        References
-        ----------
-        .. [LM] https://github.com/lmfit/lmfit-py/
+        Notes
+        -----
+        https://github.com/lmfit/lmfit-py/
+
         """
         try:
             global lmfit

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -56,13 +56,7 @@ def acf(x, lags=365, bin_method='rectangle', bin_width=0.5, max_gap=inf,
     -----
     Calculate the autocorrelation function for irregular timesteps based on
     the slotting technique. Different methods (kernels) to bin the data are
-    available.
-
-    References
-    ----------
-    Rehfeld, K., Marwan, N., Heitzig, J., Kurths, J. (2011). Comparison
-    of correlation analysis techniques for irregularly sampled time series.
-    Nonlinear Processes in Geophysics. 18. 389-404. 10.5194 pg-18-389-2011.
+    available. Method here is basec on :cite:t:`rehfeld_comparison_2011`
 
     Tip
     ---
@@ -128,12 +122,6 @@ def ccf(x, y, lags=365, bin_method='rectangle', bin_width=0.5,
     -------
     c: pandas.Series or pandas.DataFrame
         The Cross-correlation function.
-
-    References
-    ----------
-    Rehfeld, K., Marwan, N., Heitzig, J., Kurths, J. (2011). Comparison
-    of correlation analysis techniques for irregularly sampled time series.
-    Nonlinear Processes in Geophysics. 18. 389-404. 10.5194 pg-18-389-2011.
 
     Tip
     ---

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -56,7 +56,7 @@ def acf(x, lags=365, bin_method='rectangle', bin_width=0.5, max_gap=inf,
     -----
     Calculate the autocorrelation function for irregular timesteps based on
     the slotting technique. Different methods (kernels) to bin the data are
-    available. Method here is basec on :cite:t:`rehfeld_comparison_2011`
+    available. Method here is based on :cite:t:`rehfeld_comparison_2011`.
 
     Tip
     ---

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -237,7 +237,7 @@ def evp(obs, sim=None, res=None, missing="drop", weighted=False, max_gap=30):
     Notes
     -----
     Commonly used goodness-of-fit metric groundwater level models as
-    computed in [asmuth_2012]_.
+    computed in :cite:t:`von_asmuth_groundwater_2012`.
 
     .. math:: \\text{EVP} = \\frac{\\sigma_h^2 - \\sigma_r^2}{\\sigma_h^2}
         * 100
@@ -246,13 +246,6 @@ def evp(obs, sim=None, res=None, missing="drop", weighted=False, max_gap=30):
     :math:`\\sigma_r^2` is the variance of the residuals. The returned value
     is bounded between 0% and 100%.
 
-    References
-    ----------
-    .. [asmuth_2012] von Asmuth, J., K. Maas, M. Knotters, M. Bierkens,
-       M. Bakker, T.N. Olsthoorn, D.G. Cirkel, I. Leunk, F. Schaars, and D.C.
-       von Asmuth. 2012. Software for hydrogeologic time series analysis,
-       interfacing data with physical insight. Environmental Modelling &
-       Software 38: 178–130.
     """
     if res is None:
         res = sim - obs
@@ -297,15 +290,10 @@ def nse(obs, sim=None, res=None, missing="drop", weighted=False, max_gap=30):
 
     Notes
     -----
-    NSE computed according to [nash_1970]_
+    NSE computed according to :cite:t:`nash_river_1970`
 
     .. math:: \\text{NSE} = 1 - \\frac{\\sum(h_s-h_o)^2}{\\sum(h_o-\\mu_{h,o})}
 
-    References
-    ----------
-    .. [nash_1970] Nash, J. E., & Sutcliffe, J. V. (1970). River flow
-       forecasting through conceptual models part I-A discussion of
-       principles. Journal of hydrology, 10(3), 282-230.
     """
     if res is None:
         res = sim - obs
@@ -405,18 +393,12 @@ def bic(obs=None, sim=None, res=None, missing="drop", nparam=1):
 
     Notes
     -----
-    The Bayesian Information Criterium (BIC) [akaike_1979]_ is computed as
-    follows:
+    The Bayesian Information Criterium (BIC) :cite:t:`akaike_bayesian_1979`
+    is computed as follows:
 
     .. math:: \\text{BIC} = -2 log(L) + n_{param} * log(N)
 
     where :math:`n_{param}` is the number of calibration parameters.
-
-    References
-    ----------
-    .. [akaike_1979] Akaike, H. (1979). A Bayesian extension of the minimum
-       AIC procedure of autoregressive model fitting. Biometrika, 66(2),
-       237-242.
 
     """
     if res is None:
@@ -455,18 +437,13 @@ def aic(obs=None, sim=None, res=None, missing="drop", nparam=1):
 
     Notes
     -----
-    The Akaike Information Criterium (AIC) [akaike_1974]_ is computed as
-    follows:
+    The Akaike Information Criterium (AIC) :cite:t:`akaike_new_1970` is
+    computed as follows:
 
     .. math:: \\text{AIC} = -2 log(L) + 2 nparam
 
     where :math:`n_{param}` is the number of calibration parameters and L is
     the likelihood function for the model.
-
-    References
-    ----------
-    .. [akaike_1974] Akaike, H. (1974). A new look at the statistical model
-       identification. IEEE transactions on automatic control, 19(6), 716-723.
 
     """
     if res is None:
@@ -508,7 +485,8 @@ def kge_2012(obs, sim, missing="drop", weighted=False, max_gap=30):
 
     Notes
     -----
-    The (weighted) Kling-Gupta Efficiency [kling_2012]_ is computed as follows:
+    The (weighted) Kling-Gupta Efficiency :cite:t:`kling_runoff_2012` is
+    computed as follows:
 
     .. math:: \\text{KGE} = 1 - \\sqrt{(r-1)^2 + (\\beta-1)^2 - (\\gamma-1)^2}
 
@@ -516,12 +494,6 @@ def kge_2012(obs, sim, missing="drop", weighted=False, max_gap=30):
     \\frac{\\bar{\\sigma}_x / \\bar{x}}{\\bar{\\sigma}_y / \\bar{y}}`. If
     weighted equals True, the weighted mean, variance and pearson
     correlation are used.
-
-    References
-    ----------
-    .. [kling_2012] Kling, H., Fuchs, M., and Paulin, M. (2012). Runoff
-      conditions in the upper Danube basin under an ensemble of climate
-      change scenarios. Journal of Hydrology, 424-425:264 - 277.
 
     """
     if missing == "drop":

--- a/pastas/stats/sgi.py
+++ b/pastas/stats/sgi.py
@@ -6,7 +6,8 @@ from scipy.stats import norm
 
 
 def sgi(series):
-    """Method to compute the Standardized Groundwater Index [sgi_2013]_.
+    """Method to compute the Standardized Groundwater Index
+    :cite:t:`bloomfield_analysis_2013`.
 
     Parameters
     ----------
@@ -18,11 +19,6 @@ def sgi(series):
         Pandas time series of the groundwater levels. Time series index
         should be a pandas DatetimeIndex.
 
-    References
-    ----------
-    .. [sgi_2013] Bloomfield, J. P. and Marchant, B. P.: Analysis of
-       groundwater drought building on the standardised precipitation index
-       approach, Hydrol. Earth Syst. Sci., 17, 4769–4787, 2013.
     """
     series = series.copy()  # Create a copy to ensure series is untouched.
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1148,7 +1148,7 @@ class TarsoModel(RechargeModel):
     Notes
     -----
     The Threshold autoregressive self-exciting open-loop (Tarso) model
-    :cite:t:`knotters_threshold_1999` is nonlinear in structure because it
+    :cite:t:`knotters_tarso_1999` is nonlinear in structure because it
     incorporates two regimes which are separated by a threshold. This model
     method can be used to simulate a groundwater system where the groundwater
     head reaches the surface or drainage level in wet conditions. TarsoModel

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1148,22 +1148,17 @@ class TarsoModel(RechargeModel):
     Notes
     -----
     The Threshold autoregressive self-exciting open-loop (Tarso) model
-    [knotters_1999]_ is nonlinear in structure because it incorporates two
-    regimes which are separated by a threshold. This model method can be
-    used to simulate a groundwater system where the groundwater head reaches
-    the surface or drainage level in wet conditions. TarsoModel uses two
-    drainage levels, with two exponential response functions. When the
+    :cite:t:`knotters_threshold_1999` is nonlinear in structure because it
+    incorporates two regimes which are separated by a threshold. This model
+    method can be used to simulate a groundwater system where the groundwater
+    head reaches the surface or drainage level in wet conditions. TarsoModel
+    uses two drainage levels, with two exponential response functions. When the
     simulation reaches the second drainage level, the second response
     function becomes active. Because of its structure, TarsoModel cannot be
     combined with other stress models, a constant or a transform.
     TarsoModel inherits from RechargeModel. Only parameters specific to the
     child class are named above.
 
-    References
-    ----------
-    .. [knotters_1999] Knotters, M. & De Gooijer, Jan G.. (1999). TARSO
-       modeling of water table depths. Water Resources Research. 35.
-       10.1029/1998WR900049.
     """
     _name = "TarsoModel"
 
@@ -1321,13 +1316,8 @@ class ChangeModel(StressModelBase):
 
     Notes
     -----
-    This model is based on Obergfjell et al. (2019).
+    This model is based on :cite:t:`obergfell_identification_2019`.
 
-    References
-    ----------
-    Obergfell, C., Bakker, M. and Maas, K. (2019), Identification and
-    Explanation of a Change in the Groundwater Regime using Time Series
-    Analysis. Groundwater, 57: 886-894. https://doi.org/10.1111/gwat.12891
     """
     _name = "ChangeModel"
 

--- a/requirements.rtd.txt
+++ b/requirements.rtd.txt
@@ -4,3 +4,5 @@ ipykernel
 pydata-sphinx-theme
 sphinx-gallery
 sphinx>=3.1
+sphinxcontrib-bibtex
+requests


### PR DESCRIPTION
# Short Description
See issue #435. Add a central reference page and a list of peer-reviewed articles using Pastas from Zotero. Easier to maintain and keep track of things. Plus users don't need to know about the old separate repo listing the publications. Adding a new article is as easy as adding it to the Zotero library.

I chose not to include PhD, MSc, and BSc theses nor non-published reports here. This is a lot of work to maintain with little benefit. The articles listed show the use of Pastas and have more weight.

# Checklist before PR can be merged:
- [X] closes issue #435 
- [x] is documented
- [X] PEP8 compliant code
- [x] tests added / passed

# Example pages:
- https://pastas--436.org.readthedocs.build/en/436/publications.html#publications
- https://pastas--436.org.readthedocs.build/en/436/references.html
- https://pastas--436.org.readthedocs.build/en/436/api/generated/pastas.recharge.html (citations)
