### PR TITLE
create Linear instance after instantiation

### DIFF
--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -21,7 +21,6 @@ from pandas import DataFrame, Series, Timedelta, Timestamp, concat, date_range
 from scipy.signal import fftconvolve
 import inspect
 from scipy import __version__ as scipyversion
-from warnings import warn
 
 from .decorators import njit, set_parameter
 from .recharge import Linear
@@ -813,9 +812,9 @@ class RechargeModel(StressModelBase):
     name: str, optional
         Name of the stress. Default is "recharge".
     recharge: pastas.recharge instance, optional
-        String with the name of the recharge model. Options are: Linear (
-        default), FlexModel and Berendrecht. These can be accessed through
-        ps.rch.
+        Instance of a recharge model. Options are: Linear, FlexModel and
+        Berendrecht. These can be accessed through ps.rch. If no recharge
+        model is provided, ps.rch.Linear() is used.
     temp: pandas.Series or pastas.timeseries.TimeSeries, optional
         pandas.Series or pastas.TimeSeries object containing the
         temperature series. It depends on the recharge model is this
@@ -859,15 +858,20 @@ class RechargeModel(StressModelBase):
     We recommend not to store a RechargeModel is a variable named `rm`. This
     name is already reserved in IPython to remove files and will cause
     problems later.
+
     """
     _name = "RechargeModel"
 
     def __init__(self, prec, evap, rfunc=None, name="recharge",
-                 recharge=Linear(), temp=None, cutoff=0.999,
+                 recharge=None, temp=None, cutoff=0.999,
                  settings=("prec", "evap", "evap"),
                  metadata=(None, None, None)):
         if rfunc is None:
             rfunc = Exponential()
+
+        if recharge is None:
+            recharge = Linear()
+
         # Store the precipitation and evaporation time series
         self.prec = TimeSeries(prec, settings=settings[0],
                                metadata=metadata[0])


### PR DESCRIPTION
# Short Description
As per Issue #423, instantiate ps.rch.Linear() when creating a RechargeModel instance, not on import of Pastas.

# Checklist before PR can be merged:
- [x] closes issue #423
- [x] is documented
- [x] PEP8 compliant code
- [x] tests added / passed
- [ ] Example Notebook (for new features)
- [x] API changes documented in Release Notes
