### PR TITLE
442 fix python-publish.yml and improve version.py

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install wheel twine build
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python3 -m build
+        python3 -m twine upload --repository pypi dist/*

--- a/doc/concepts/hantush_response.ipynb
+++ b/doc/concepts/hantush_response.ipynb
@@ -179,7 +179,7 @@
     "print(\"Hantush numerical integration (quad):\")\n",
     "%timeit rf_quad.step([-0.05, 200, 0.5])\n",
     "\n",
-    "if ps.utils.check_numba_scipy():\n",
+    "if ps.version.check_numba_scipy():\n",
     "    rf_numba = ps.Hantush(use_numba=True)\n",
     "    print(\"Hantush approximation (numba):\")\n",
     "    %timeit rf_numba.step([-0.05, 200, 0.5])"
@@ -700,7 +700,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('artesia')",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -714,11 +714,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "dace5e1b41a98a8e52d2a8eebc3b981caf2c12e7a76736ebfb89a489e3b62e79"
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
    }
   }
  },

--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -38,8 +38,8 @@ from .stressmodels import (
 )
 from .timeseries import TimeSeries
 from .transform import ThresholdTransform
-from .utils import initialize_logger, set_log_level, show_versions
-from .version import __version__
+from .utils import initialize_logger, set_log_level
+from .version import __version__, show_versions
 
 logger = logging.getLogger(__name__)
 initialize_logger(logger)

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -29,7 +29,7 @@ from pandas import DataFrame, Series, Timedelta
 from pastas.typing import ArrayLike
 
 from .decorators import njit, set_parameter
-from .utils import check_numba
+from .version import check_numba
 
 __all__ = ["NoiseModel", "ArmaModel"]
 

--- a/pastas/recharge.py
+++ b/pastas/recharge.py
@@ -46,7 +46,7 @@ from pandas import DataFrame
 from pastas.typing import ArrayLike
 
 from .decorators import njit
-from .utils import check_numba
+from .version import check_numba
 
 logger = getLogger(__name__)
 

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -20,7 +20,7 @@ from scipy.special import (
 )
 
 from .decorators import njit
-from .utils import check_numba, check_numba_scipy
+from .version import check_numba, check_numba_scipy
 
 try:
     from numba import prange

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -29,7 +29,7 @@ from scipy.stats import norm
 from pastas.typing import ArrayLike
 
 from ..decorators import njit
-from ..utils import check_numba
+from ..version import check_numba
 
 
 def acf(

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -16,13 +16,13 @@ pastas.model.Model.add_stressmodel
 
 import inspect
 from logging import getLogger
+from importlib.metadata import version
 
 # Type Hinting
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat, date_range
-from scipy import __version__ as scipyversion
 from scipy.signal import fftconvolve
 
 from pastas.typing import ArrayLike, Model, Recharge, RFunc, TimestampType
@@ -31,7 +31,8 @@ from .decorators import njit, set_parameter
 from .recharge import Linear
 from .rfunc import Exponential, HantushWellModel, One
 from .timeseries import TimeSeries
-from .utils import check_numba, validate_name
+from .utils import validate_name
+from .version import check_numba
 
 logger = getLogger(__name__)
 
@@ -666,10 +667,7 @@ class WellModel(StressModelBase):
                 "WellModel only supports the rfunc " "HantushWellModel!"
             )
 
-        # Check if scipy < 1.8
-        from packaging import version
-
-        if version.parse(scipyversion) < version.parse("1.8.0"):
+        if version("scipy") < "1.8.0":
             logger.warning(
                 "It is recommended to use LmfitSolve as the solver "
                 "or update to scipy>=1.8.0 when implementing WellModel."

--- a/pastas/utils.py
+++ b/pastas/utils.py
@@ -9,7 +9,6 @@ from platform import platform
 from typing import Any, Optional, Tuple
 
 import numpy as np
-from packaging import version
 from pandas import (
     DatetimeIndex,
     Index,
@@ -20,7 +19,6 @@ from pandas import (
     to_datetime,
 )
 from pandas.tseries.frequencies import to_offset
-from scipy import __version__ as sc_version
 from scipy import interpolate
 
 from pastas.typing import ArrayLike
@@ -676,69 +674,3 @@ def validate_name(name: str, raise_error: bool = False) -> str:
                 logger.warning(msg)
 
     return name
-
-
-def show_versions(lmfit: bool = False, numba: bool = False) -> None:
-    """Method to print the version of dependencies.
-
-    Parameters
-    ----------
-    lmfit: bool, optional
-        Print the version of lmfit. Needs to be installed.
-    numba: bool, optional
-        Print the version of numba. Needs to be installed.
-    """
-    from sys import version as os_version
-
-    from matplotlib import __version__ as mpl_version
-    from numpy import __version__ as np_version
-    from pandas import __version__ as pd_version
-
-    from pastas import __version__ as ps_version
-
-    msg = (
-        f"Python version: {os_version}\n"
-        f"NumPy version: {np_version}\n"
-        f"SciPy version: {sc_version}\n"
-        f"Pandas version: {pd_version}\n"
-        f"Pastas version: {ps_version}\n"
-        f"Matplotlib version: {mpl_version}"
-    )
-
-    if lmfit:
-        from lmfit import __version__ as lm_version
-
-        msg = msg + f"\nlmfit version: {lm_version}"
-    if numba:
-        from numba import __version__ as nb_version
-
-        msg = msg + f"\nnumba version: {nb_version}"
-
-    return print(msg)
-
-
-def check_numba() -> None:
-    try:
-        from numba import njit
-    except ImportError:
-        logger.warning(
-            "Numba is not installed. Installing Numba is "
-            "recommended for significant speed-ups."
-        )
-
-
-def check_numba_scipy():
-    try:
-        import numba_scipy as _
-    except ImportError:
-        logger.warning(
-            "numba_scipy is not installed, defaulting to numpy implementation."
-        )
-        return False
-
-    if version.parse(sc_version) > version.parse("1.7.3"):
-        logger.warning(
-            "numba_scipy supports scipy<=1.7.3, found {0}".format(sc_version)
-        )
-        return False
-    return True

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -1,3 +1,79 @@
-from importlib.metadata import version
+import logging
+from platform import python_version
+from importlib import import_module, metadata
 
-__version__ = version("pastas")
+__version__ = metadata.version("pastas")
+logger = logging.getLogger(__name__)
+
+
+def check_numba() -> None:
+    try:
+        import_module("numba")
+    except ModuleNotFoundError:
+        logger.warning(
+            "Numba is not installed. Installing Numba is "
+            "recommended for significant speed-ups."
+        )
+
+
+def check_numba_scipy() -> bool:
+    try:
+        import_module("numba_scipy")
+    except ModuleNotFoundError:
+        logger.warning(
+            "numba_scipy is not installed, defaulting to numpy implementation."
+        )
+        return False
+
+    scipy_version = metadata.version("scipy")
+    scipy_version_nsc = [x for x in metadata.requires("numba-scipy") if "scipy" in x][0]
+    scipy_version_nsc = scipy_version_nsc.split(",")[0].split("=")[-1]
+    if scipy_version > scipy_version_nsc:
+        logger.warning(
+            f"numba_scipy supports SciPy<={scipy_version_nsc}, found {scipy_version}"
+        )
+        return False
+    return True
+
+def show_versions(lmfit: bool = True, numba: bool = True) -> None:
+    """Method to print the version of dependencies.
+
+    Parameters
+    ----------
+    lmfit: bool, optional
+        Print the version of LMfit. Needs to be installed.
+    numba: bool, optional
+        Print the version of Numba. Needs to be installed.
+    """
+
+    msg = (
+        f"Python version: {python_version()}\n"
+        f"NumPy version: {metadata.version('numpy')}\n"
+        f"Pandas version: {metadata.version('pandas')}\n"
+        f"SciPy version: {metadata.version('scipy')}\n"
+        f"Matplotlib version: {metadata.version('matplotlib')}"
+    )
+
+    if lmfit:
+        msg += "\nLMfit version: "
+        try:
+           import_module("lmfit")
+           msg += f"{metadata.version('lmfit')}"
+        except ModuleNotFoundError:
+            msg += "Not Installed"
+
+    if numba:
+        msg += "\nNumba version: "
+        try:
+            import_module("numba")
+            msg += f"{metadata.version('numba')}"
+        except ModuleNotFoundError:
+            msg += "Not Installed"
+
+    msg += f"\nPastas version: {metadata.version('pastas')}"
+
+    return print(msg)
+
+
+if __name__ == "__main__":
+    check_numba()

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -10,8 +10,10 @@ def check_numba() -> None:
     try:
         import_module("numba")
     except ModuleNotFoundError:
-        logger.warning("Numba is not installed. Installing Numba is "
-                       "recommended for significant speed-ups.")
+        logger.warning(
+            "Numba is not installed. Installing Numba is "
+            "recommended for significant speed-ups."
+        )
 
 
 def check_numba_scipy() -> bool:
@@ -24,9 +26,7 @@ def check_numba_scipy() -> bool:
         return False
 
     scipy_version = metadata.version("scipy")
-    scipy_version_nsc = [
-        x for x in metadata.requires("numba-scipy") if "scipy" in x
-    ]
+    scipy_version_nsc = [x for x in metadata.requires("numba-scipy") if "scipy" in x]
     scipy_version_nsc = scipy_version_nsc[0].split(",")[0].split("=")[-1]
     if scipy_version > scipy_version_nsc:
         logger.warning(
@@ -47,11 +47,13 @@ def show_versions(lmfit: bool = True, numba: bool = True) -> None:
         Print the version of Numba. Needs to be installed.
     """
 
-    msg = (f"Python version: {python_version()}\n"
-           f"NumPy version: {metadata.version('numpy')}\n"
-           f"Pandas version: {metadata.version('pandas')}\n"
-           f"SciPy version: {metadata.version('scipy')}\n"
-           f"Matplotlib version: {metadata.version('matplotlib')}")
+    msg = (
+        f"Python version: {python_version()}\n"
+        f"NumPy version: {metadata.version('numpy')}\n"
+        f"Pandas version: {metadata.version('pandas')}\n"
+        f"SciPy version: {metadata.version('scipy')}\n"
+        f"Matplotlib version: {metadata.version('matplotlib')}"
+    )
 
     if lmfit:
         msg += "\nLMfit version: "

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -10,10 +10,8 @@ def check_numba() -> None:
     try:
         import_module("numba")
     except ModuleNotFoundError:
-        logger.warning(
-            "Numba is not installed. Installing Numba is "
-            "recommended for significant speed-ups."
-        )
+        logger.warning("Numba is not installed. Installing Numba is "
+                       "recommended for significant speed-ups.")
 
 
 def check_numba_scipy() -> bool:
@@ -26,14 +24,17 @@ def check_numba_scipy() -> bool:
         return False
 
     scipy_version = metadata.version("scipy")
-    scipy_version_nsc = [x for x in metadata.requires("numba-scipy") if "scipy" in x][0]
-    scipy_version_nsc = scipy_version_nsc.split(",")[0].split("=")[-1]
+    scipy_version_nsc = [
+        x for x in metadata.requires("numba-scipy") if "scipy" in x
+    ]
+    scipy_version_nsc = scipy_version_nsc[0].split(",")[0].split("=")[-1]
     if scipy_version > scipy_version_nsc:
         logger.warning(
             f"numba_scipy supports SciPy<={scipy_version_nsc}, found {scipy_version}"
         )
         return False
     return True
+
 
 def show_versions(lmfit: bool = True, numba: bool = True) -> None:
     """Method to print the version of dependencies.
@@ -46,19 +47,17 @@ def show_versions(lmfit: bool = True, numba: bool = True) -> None:
         Print the version of Numba. Needs to be installed.
     """
 
-    msg = (
-        f"Python version: {python_version()}\n"
-        f"NumPy version: {metadata.version('numpy')}\n"
-        f"Pandas version: {metadata.version('pandas')}\n"
-        f"SciPy version: {metadata.version('scipy')}\n"
-        f"Matplotlib version: {metadata.version('matplotlib')}"
-    )
+    msg = (f"Python version: {python_version()}\n"
+           f"NumPy version: {metadata.version('numpy')}\n"
+           f"Pandas version: {metadata.version('pandas')}\n"
+           f"SciPy version: {metadata.version('scipy')}\n"
+           f"Matplotlib version: {metadata.version('matplotlib')}")
 
     if lmfit:
         msg += "\nLMfit version: "
         try:
-           import_module("lmfit")
-           msg += f"{metadata.version('lmfit')}"
+            import_module("lmfit")
+            msg += f"{metadata.version('lmfit')}"
         except ModuleNotFoundError:
             msg += "Not Installed"
 
@@ -73,7 +72,3 @@ def show_versions(lmfit: bool = True, numba: bool = True) -> None:
     msg += f"\nPastas version: {metadata.version('pastas')}"
 
     return print(msg)
-
-
-if __name__ == "__main__":
-    check_numba()


### PR DESCRIPTION
# Short Description
These are some leftover fixes from the #443 change. There was still a reference to setup.py in the python-publish.yml while setup.py was removed in favor of pyproject.toml. Additionaly, on request of @raoulcollenteur some version checking functions are moved to version.py. 

# Checklist before PR can be merged:
- [x] closes issue #442 
- [x] is documented
- [x] PEP8 compliant code