### PR TITLE
Have acf return conf instead of stderr

### DIFF
--- a/pastas/modelcompare.py
+++ b/pastas/modelcompare.py
@@ -184,8 +184,8 @@ class CompareModels:
                 smnames = self.smdict[int(ky[3:])]  # index is after 'con'
                 # fmt: off
                 heights[ky] = (
-                    np.nanmax(contrib_minmax.loc[smnames, "max"]) -
-                    np.nanmin(contrib_minmax.loc[smnames, "min"])
+                        np.nanmax(contrib_minmax.loc[smnames, "max"]) -
+                        np.nanmin(contrib_minmax.loc[smnames, "min"])
                 )
                 # fmt: on
 
@@ -644,7 +644,7 @@ class CompareModels:
             else:
                 r = ps.stats.core.acf(ml.residuals(), full_output=True)
                 label = "Autocorrelation Residuals"
-            conf = r.stderr.rolling(10, min_periods=1).mean().values
+            conf = r.conf.rolling(10, min_periods=1).mean().values
 
             self.axes[axn].fill_between(
                 r.index.days, conf, -conf, alpha=0.3, color=self.cmap(i)
@@ -664,8 +664,8 @@ class CompareModels:
         ----------
         axn : str, optional
             name of labeled axes to plot table on, by default "table"
-        df : pandas DataFrame
-            Pandas Dataframe to plot. Note that the first column is the index
+        df : pandas.DataFrame
+            The Pandas.Dataframe to plot. Note that the first column is the index
             column that is shown.
         """
         if self.axes is None:

--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -293,15 +293,14 @@ def acf(
 
     if r.empty:
         raise ValueError(
-            "The computed autocorrelation function has no "
-            "values. Changing the input arguments ('acf_options')"
-            " for calculating ACF may help."
+            "The computed autocorrelation function has no values. Changing the input "
+            "arguments ('acf_options') for calculating ACF may help."
         )
 
     if smooth_conf:
-        conf = r.stderr.rolling(10, min_periods=1).mean().values
+        conf = r.conf.rolling(10, min_periods=1).mean().values
     else:
-        conf = r.stderr.values
+        conf = r.conf.values
 
     ax.fill_between(r.index.days, conf, -conf, alpha=0.3)
     ax.vlines(r.index.days, [0], r.loc[:, "acf"].values, color=color)

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -1,8 +1,8 @@
 """The following methods may be used to calculate the crosscorrelation and
 autocorrelation for a time series.
 
-These methods are 'special' in the sense that they are able to deal with
-irregular time steps often observed in hydrological time series.
+These methods are 'special' in the sense that they are able to deal with irregular
+time steps often observed in hydrological time series.
 """
 
 # Type Hinting
@@ -47,25 +47,24 @@ def acf(
     Parameters
     ----------
     x: pandas.Series
-        Pandas Series containing the values to calculate the
-        cross-correlation for. The index has to be a Pandas.DatetimeIndex
+        Pandas Series containing the values to calculate the cross-correlation on.
+        The index has to be a Pandas.DatetimeIndex.
     lags: array_like, optional
-        numpy array containing the lags in days for which the
-        cross-correlation if calculated. [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12,
-        13, 14, 30, 61, 90, 120, 150, 180, 210, 240, 270, 300, 330, 365]
+        numpy array containing the lags in days for which the cross-correlation if
+        calculated. [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 30, 61, 90, 120, 150,
+        180, 210, 240, 270, 300, 330, 365].
     bin_method: str, optional
         method to determine the type of bin. Options are "rectangle" (default),
         and  "gaussian".
     bin_width: float, optional
-        number of days used as the width for the bin to calculate the
-        correlation. By default these values are chosen based on the
-        bin_method and the average time step (dt_mu). That is 0.5dt_mu when
-        bin_method="rectangle" and 0.25dt_mu when bin_method="gaussian".
+        number of days used as the width for the bin to calculate the correlation.
+        By default, these values are chosen based on the bin_method and the average
+        time step (dt_mu). That is 0.5dt_mu when bin_method="rectangle" and 0.25dt_mu
+        when bin_method="gaussian".
     max_gap: float, optional
-        Maximum time step gap in the data. All time steps above this gap value
-        are not used for calculating the average time step. This can be
-        helpful when there is a large gap in the data that influences the
-        average time step.
+        Maximum time step gap in the data. All time steps above this gap value are
+        not used for calculating the average time step. This can be helpful when
+        there is a large gap in the data that influences the average time step.
     min_obs: int, optional
         Minimum number of observations in a bin to determine the correlation.
     full_output: bool, optional
@@ -75,24 +74,27 @@ def acf(
 
     Returns
     -------
-    c: pandas.Series or pandas.DataFrame
-        The autocorrelation function for the provided lags.
+    result: pandas.Series or pandas.DataFrame
+        If full_output=True, a DataFrame with columns "acf", "conf", and "n",
+        containning the autocorrelation function, confidence intervals (depends on
+        alpha), and the number of samples n used to compute these, respectively. If
+        full_output=False, only the ACF is returned.
 
     Notes
     -----
-    Calculate the autocorrelation function for irregular timesteps based on
-    the slotting technique. Different methods (kernels) to bin the data are
-    available. Method here is based on :cite:t:`rehfeld_comparison_2011`.
+    Calculate the autocorrelation function for irregular timesteps based on the
+    slotting technique. Different methods (kernels) to bin the data are available.
+    Method here is based on :cite:t:`rehfeld_comparison_2011`.
 
     Tip
     ---
-    If the time series have regular time step we recommend to use the acf
-    method from the Statsmodels package.
+    If the time series have regular time step we recommend to use the acf method from
+    the Statsmodels package.
 
     Examples
     --------
-    For example, to estimate the autocorrelation for every second lag up to
-    lags of one year:
+    For example, to estimate the autocorrelation for every second lag up to lags of
+    one year:
 
     >>> acf = ps.stats.acf(x, lags=np.arange(1.0, 366.0, 2.0))
 
@@ -135,25 +137,24 @@ def ccf(
     Parameters
     ----------
     x,y: pandas.Series
-        Pandas Series containing the values to calculate the
-        cross-correlation for. The index has to be a Pandas.DatetimeIndex
+        Pandas Series containing the values to calculate the cross-correlation on.
+        The index has to be a Pandas.DatetimeIndex.
     lags: array_like, optional
-        numpy array containing the lags in days for which the
-        cross-correlation is calculated. Default [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        12, 13, 14, 30, 61, 90, 120, 150, 180, 210, 240, 270, 300, 330, 365]
+        numpy array containing the lags in days for which the cross-correlation is
+        calculated. Default [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 30, 61, 90,
+        120, 150, 180, 210, 240, 270, 300, 330, 365].
     bin_method: str, optional
         method to determine the type of bin. Options are "rectangle" (default),
         "gaussian" and "regular" (for regular timesteps).
     bin_width: float, optional
-        number of days used as the width for the bin to calculate the
-        correlation. By default these values are chosen based on the
-        bin_method and the average time step (dt_mu). That is 0.5dt_mu when
-        bin_method="rectangle" and 0.25dt_mu when bin_method="gaussian".
+        number of days used as the width for the bin to calculate the correlation. By
+        default, these values are chosen based on the bin_method and the average time
+        step (dt_mu). That is 0.5dt_mu when bin_method="rectangle" and 0.25dt_mu when
+        bin_method="gaussian".
     max_gap: float, optional
-        Maximum timestep gap in the data. All timesteps above this gap value
-        are not used for calculating the average timestep. This can be
-        helpful when there is a large gap in the data that influences the
-        average timestep.
+        Maximum timestep gap in the data. All timesteps above this gap value are not
+        used for calculating the average timestep. This can be helpful when there is
+        a large gap in the data that influences the average timestep.
     min_obs: int, optional
         Minimum number of observations in a bin to determine the correlation.
     full_output: bool, optional
@@ -163,13 +164,16 @@ def ccf(
 
     Returns
     -------
-    c: pandas.Series or pandas.DataFrame
-        The Cross-correlation function.
+    result: pandas.Series or pandas.DataFrame
+        If full_output=True, a DataFrame with columns "ccf", "conf", and "n",
+        containning the cross-correlation function, confidence intervals (depends on
+        alpha), and the number of samples n used to compute these, respectively. If
+        full_output=False, only the CCF is returned.
 
     Tip
     ---
-    This method will be significantly faster when Numba is installed. Check
-    out the [Numba project here](https://numba.pydata.org)
+    This method will be significantly faster when Numba is installed. Check out the [
+    Numba project here](https://numba.pydata.org)
 
     Examples
     --------
@@ -180,13 +184,12 @@ def ccf(
         bin_method = "regular"
     elif bin_method == "regular":
         raise Warning(
-            "time series does not have regular time steps, "
-            "choose different bin_method"
+            "time series does not have regular time steps, choose different bin_method."
         )
 
     x, t_x, dt_x_mu = _preprocess(x, max_gap=max_gap)
     y, t_y, dt_y_mu = _preprocess(y, max_gap=max_gap)
-    dt_mu = max(dt_x_mu, dt_y_mu)  # Mean time step from both series
+    dt_mu = max(dt_x_mu, dt_y_mu)  # The mean time step from both series
 
     if isinstance(lags, int) and bin_method == "regular":
         lags = arange(int(dt_mu), lags + 1, int(dt_mu), dtype=float)
@@ -210,9 +213,9 @@ def ccf(
     else:
         raise NotImplementedError
 
-    std = norm.ppf(1 - alpha / 2.0) / sqrt(b)
+    conf = norm.ppf(1 - alpha / 2.0) / sqrt(b)
     result = DataFrame(
-        data={"ccf": c, "stderr": std, "n": b},
+        data={"ccf": c, "conf": conf, "n": b},
         index=TimedeltaIndex(lags, unit="D", name="Lags"),
     )
 
@@ -224,7 +227,7 @@ def ccf(
         return result.ccf
 
 
-def _preprocess(x: Series, max_gap: int) -> Tuple[Series, float, float]:
+def _preprocess(x: Series, max_gap: float) -> Tuple[ArrayLike, ArrayLike, float]:
     """Internal method to preprocess the time series."""
     dt = x.index.to_series().diff().dropna().values / Timedelta(1, "D")
     dt_mu = dt[dt < max_gap].mean()  # Deal with big gaps if present
@@ -324,12 +327,12 @@ def mean(x: Series, weighted: bool = True, max_gap: int = 30) -> ArrayLike:
     x: pandas.Series
         Series with the values and a DatetimeIndex as an index.
     weighted: bool, optional
-        Weight the values by the normalized time step to account for
-        irregular time series. Default is True.
+        Weight the values by the normalized time step to account for irregular time
+        series. Default is True.
     max_gap: int, optional
-        maximum allowed gap period in days to use for the computation of the
-        weights. All time steps larger than max_gap are replace with the
-        mean weight. Default value is 90 days.
+        maximum allowed gap period in days to use for the computation of the weights.
+        All time steps larger than max_gap are replace with the mean weight. Default
+        value is 90 days.
 
     Notes
     -----
@@ -337,8 +340,8 @@ def mean(x: Series, weighted: bool = True, max_gap: int = 30) -> ArrayLike:
 
     .. math:: \\bar{x} = \\sum_{i=1}^{N} w_i x_i
 
-    where :math:`w_i` are the weights, taken as the time step between
-    observations, normalized by the sum of all time steps.
+    where :math:`w_i` are the weights, taken as the time step between observations,
+    normalized by the sum of all time steps.
     """
     w = _get_weights(x, weighted=weighted, max_gap=max_gap)
     return average(x.to_numpy(), weights=w)
@@ -352,12 +355,12 @@ def var(x: Series, weighted: bool = True, max_gap: int = 30) -> ArrayLike:
     x: pandas.Series
         Series with the values and a DatetimeIndex as an index.
     weighted: bool, optional
-        Weight the values by the normalized time step to account for
-        irregular time series. Default is True.
+        Weight the values by the normalized time step to account for irregular time
+        series. Default is True.
     max_gap: int, optional
-        maximum allowed gap period in days to use for the computation of the
-        weights. All time steps larger than max_gap are replace with the
-        mean weight. Default value is 90 days.
+        maximum allowed gap period in days to use for the computation of the weights.
+        All time steps larger than max_gap are replace with the mean weight. Default
+        value is 90 days.
 
     Notes
     -----
@@ -365,9 +368,9 @@ def var(x: Series, weighted: bool = True, max_gap: int = 30) -> ArrayLike:
 
     .. math:: \\sigma_x^2 = \\sum_{i=1}^{N} w_i (x_i - \\bar{x})^2
 
-    where :math:`w_i` are the weights, taken as the time step between
-    observations, normalized by the sum of all time steps. Note how
-    weighted mean (:math:`\\bar{x}`) is used in this formula.
+    where :math:`w_i` are the weights, taken as the time step between observations,
+    normalized by the sum of all time steps. Note how weighted mean (:math:`\\bar{
+    x}`) is used in this formula.
     """
     w = _get_weights(x, weighted=weighted, max_gap=max_gap)
     mu = average(x.to_numpy(), weights=w)
@@ -383,12 +386,12 @@ def std(x: Series, weighted: bool = True, max_gap: int = 30) -> ArrayLike:
     x: pandas.Series
         Series with the values and a DatetimeIndex as an index.
     weighted: bool, optional
-        Weight the values by the normalized time step to account for
-        irregular time series. Default is True.
+        Weight the values by the normalized time step to account for irregular time
+        series. Default is True.
     max_gap: int, optional
-        maximum allowed gap period in days to use for the computation of the
-        weights. All time steps larger than max_gap are replace with the
-        mean weight. Default value is 90 days.
+        maximum allowed gap period in days to use for the computation of the weights.
+        All time steps larger than max_gap are replace with the mean weight. Default
+        value is 90 days.
 
     See Also
     --------
@@ -408,12 +411,12 @@ def _get_weights(x: Series, weighted: bool = True, max_gap: int = 30) -> ArrayLi
     x: pandas.Series
         Series with the values and a DatetimeIndex as an index.
     weighted: bool, optional
-        Weight the values by the normalized time step to account for
-        irregular time series.
+        Weight the values by the normalized time step to account for irregular time
+        series.
     max_gap: int, optional
-        maximum allowed gap period in days to use for the computation of the
-        weights. All time steps larger than max_gap are replace with the
-        mean weight. Default value is 30 days.
+        maximum allowed gap period in days to use for the computation of the weights.
+        All time steps larger than max_gap are replace with the mean weight. Default
+        value is 30 days.
     """
     if weighted:
         w = append(0.0, diff(x.index.to_numpy()) / Timedelta("1D"))


### PR DESCRIPTION
# Short Description

Address issue 434 and make return of columns names in ps.stats.core.acf consistent.

- Only a naming issue here, changed return name from stderr to conf.
- Updated some type hints and black formatting along the way.

# Checklist before PR can be merged:
- [x] closes issue #434
- [x] is documented
- [x] PEP8 compliant code
- [x] tests added / passed
