### PR TITLE
452 Change Numba from optional to full dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Pastas: Analysis of Groundwater Time Series
 .. image:: https://img.shields.io/pypi/l/pastas.svg
    :target: https://mit-license.org/
 .. image:: https://img.shields.io/pypi/pyversions/pastas
-   :target: https://pypi.python.org/pypi/pastas      
-.. image:: https://api.codacy.com/project/badge/Grade/952f41c453854064ba0ee1fa0a0b4434    
+   :target: https://pypi.python.org/pypi/pastas
+.. image:: https://api.codacy.com/project/badge/Grade/952f41c453854064ba0ee1fa0a0b4434
    :target: https://www.codacy.com/gh/pastas/pastas
 .. image:: https://api.codacy.com/project/badge/Coverage/952f41c453854064ba0ee1fa0a0b4434
    :target: https://www.codacy.com/gh/pastas/pastas
@@ -26,7 +26,7 @@ Pastas: Analysis of Groundwater Time Series
 
 Pastas: what is it?
 ~~~~~~~~~~~~~~~~~~~
-Pastas is an open source python package for processing, simulating and analyzing 
+Pastas is an open source python package for processing, simulating and analyzing
 groundwater time series. The object oriented structure allows for the quick
 implementation of new model components. Time series models can be created,
 calibrated, and analysed with just a few lines of python code with the
@@ -66,8 +66,8 @@ Update
 ------
 To update pastas, use::
 
-  pip install pastas --upgrade  
-  
+  pip install pastas --upgrade
+
 Developers
 ----------
 To get the latest development version, use::
@@ -76,7 +76,7 @@ To get the latest development version, use::
 
 Related packages
 ~~~~~~~~~~~~~~~~
-- `Pastastore <https://github.com/pastas/pastastore>`_ is a Python package for managing multiple timeseries and pastas models 
+- `Pastastore <https://github.com/pastas/pastastore>`_ is a Python package for managing multiple timeseries and pastas models
 - `Hydropandas <https://github.com/ArtesiaWater/hydropandas/blob/master/examples/03_hydropandas_and_pastas.ipynb>`_ can be used to obtain Dutch timeseries (KNMI, Dinoloket, ..)
 - `PyEt <https://github.com/phydrus/pyet>`_ can be used to compute potential evaporation from meteorological variables.
 
@@ -91,10 +91,9 @@ Pastas
 - matplotlib>=3.1
 - pandas>=1.1
 - scipy>=1.3
+- numba>=0.51
 
-Apart from this, is is highly recommended to install Numba (>0.51) to
-gain significant speed-ups. To install Numba (and another optional 
-dependency LmFit) at the same time with Pastas use::
+To install the most important optional dependencies (solvers such as LmFit) at the same time with Pastas use::
 
    pip install pastas[full]
 

--- a/doc/concepts/armamodel.ipynb
+++ b/doc/concepts/armamodel.ipynb
@@ -33,7 +33,7 @@
     "import pastas as ps\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {

--- a/doc/concepts/noisemodel.ipynb
+++ b/doc/concepts/noisemodel.ipynb
@@ -24,7 +24,7 @@
     "import pastas as ps\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {

--- a/doc/examples/03_diagnostic_checking.ipynb
+++ b/doc/examples/03_diagnostic_checking.ipynb
@@ -56,7 +56,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {
@@ -489,7 +489,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -503,7 +503,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
+   }
   }
  },
  "nbformat": 4,

--- a/doc/examples/07_non_linear_recharge.ipynb
+++ b/doc/examples/07_non_linear_recharge.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -15,14 +16,7 @@
     "- `Peterson` ([Peterson & Western, 2014](#References))\n",
     "\n",
     "The first model is a simple linear function of precipitation and potential evaporation while the latter two are simulate a non-linear response of recharge to precipitation using a soil-water balance concepts. Detailed descriptions of these models can be found in articles listed in the [References](#References) at the end of this notebook.\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "    \n",
-    "<b>Tip</b> \n",
-    "    \n",
-    "To run this notebook and the related non-linear recharge models, it is strongly recommended to install Numba (http://numba.pydata.org). This Just-In-Time (JIT) compiler compiles the computationally intensive part of the recharge calculation, making the non-linear model as fast as the Linear recharge model.\n",
-    "    \n",
-    "</div>\n"
+    "\n"
    ]
   },
   {

--- a/doc/examples/07_non_linear_recharge.ipynb
+++ b/doc/examples/07_non_linear_recharge.ipynb
@@ -35,7 +35,7 @@
     "import pastas as ps\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "ps.show_versions(numba=True)\n",
+    "ps.show_versions()\n",
     "ps.set_log_level(\"INFO\")"
    ]
   },
@@ -155,7 +155,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -169,7 +169,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
+   }
   }
  },
  "nbformat": 4,

--- a/doc/examples/13_timestep_analysis.ipynb
+++ b/doc/examples/13_timestep_analysis.ipynb
@@ -34,7 +34,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {
@@ -397,7 +397,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -411,7 +411,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
+   }
   }
  },
  "nbformat": 4,

--- a/doc/examples/14_recharge_estimation.ipynb
+++ b/doc/examples/14_recharge_estimation.ipynb
@@ -28,7 +28,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True, lmfit=True)"
+    "ps.show_versions(lmfit=True)"
    ]
   },
   {
@@ -415,7 +415,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -429,7 +429,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
+   }
   }
  },
  "nbformat": 4,

--- a/doc/examples/16_changing_responses.ipynb
+++ b/doc/examples/16_changing_responses.ipynb
@@ -25,7 +25,7 @@
     "import pastas as ps\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {
@@ -260,7 +260,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -274,7 +274,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
+   }
   }
  },
  "nbformat": 4,

--- a/doc/examples/18_snowmodel.ipynb
+++ b/doc/examples/18_snowmodel.ipynb
@@ -26,7 +26,7 @@
     "import pastas as ps\n",
     "\n",
     "ps.set_log_level(\"ERROR\")\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {
@@ -198,7 +198,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pastas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -212,7 +212,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.15 | packaged by conda-forge | (main, Nov 22 2022, 08:41:22) [MSC v.1929 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29475f8be425919747d373d827cb41e481e140756dd3c75aa328bf3399a0138e"
+   }
   }
  },
  "nbformat": 4,

--- a/doc/examples/20_signatures.ipynb
+++ b/doc/examples/20_signatures.ipynb
@@ -37,7 +37,7 @@
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.gridspec import GridSpec\n",
     "\n",
-    "ps.show_versions(numba=True)"
+    "ps.show_versions()"
    ]
   },
   {

--- a/doc/userguide/getting_started.rst
+++ b/doc/userguide/getting_started.rst
@@ -52,17 +52,16 @@ Pastas::
     scipy
     pandas
     matplotlib
+    numba  #(large speed-up, highly recommended)
 
 Other optional, but recommended dependencies include::
 
-    numba  #(large speed-up, highly recommended)
     jupyter  #(for running notebooks)
     lmfit  #(alternative solver)
 
-
 .. tip::
-    Installing Numba is highly recommended when using Pastas. Not only this
-    package, but also pandas makes use of Numba. Since Pastas partly
+    Numba is highly recommended when using Pastas. Not only this
+    package, but also Pandas makes use of Numba. Since Pastas partly
     depends on Pandas, installing Numba will also speed up Pastas.
 
 

--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -6,6 +6,7 @@ import pastas.plots as plots
 import pastas.recharge as rch
 import pastas.stats as stats
 
+from .decorators import set_use_numba
 from .model import Model
 from .modelcompare import CompareModels
 from .noisemodels import ArmaModel, NoiseModel

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -3,6 +3,13 @@ from logging import getLogger
 
 logger = getLogger(__name__)
 
+USE_NUMBA = True
+
+
+def set_use_numba(b: bool) -> None:
+    global USE_NUMBA
+    USE_NUMBA = b
+
 
 def set_parameter(function):
     @wraps(function)
@@ -62,10 +69,13 @@ def PastasDeprecationWarning(function):
 def njit(function=None, parallel=False):
     def njit_decorator(f):
         try:
-            from numba import njit
+            if not USE_NUMBA:
+                return f
+            else:
+                from numba import njit
 
-            fnumba = njit(f, parallel=parallel)
-            return fnumba
+                fnumba = njit(f, parallel=parallel)
+                return fnumba
         except ImportError:
             return f
 

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -29,7 +29,6 @@ from pandas import DataFrame, Series, Timedelta
 from pastas.typing import ArrayLike
 
 from .decorators import njit, set_parameter
-from .version import check_numba
 
 __all__ = ["NoiseModel", "ArmaModel"]
 
@@ -217,7 +216,6 @@ class ArmaModel(NoiseModelBase):
     _name = "ArmaModel"
 
     def __init__(self) -> None:
-        check_numba()
         NoiseModelBase.__init__(self)
         self.nparam = 2
         self.set_init_parameters()

--- a/pastas/recharge.py
+++ b/pastas/recharge.py
@@ -339,9 +339,6 @@ class FlexModel(RechargeBase):
         pe: array_like
             Incoming infiltration flux in mm/d.
 
-        Notes
-        -----
-        If Numba is available, this method is significantly faster.
         """
         n = pe.size
         # Create empty arrays to store the fluxes and states

--- a/pastas/recharge.py
+++ b/pastas/recharge.py
@@ -45,7 +45,6 @@ from pandas import DataFrame
 from pastas.typing import ArrayLike
 
 from .decorators import njit
-from .version import check_numba
 
 logger = getLogger(__name__)
 
@@ -184,7 +183,6 @@ class FlexModel(RechargeBase):
     def __init__(
         self, interception: bool = True, snow: bool = False, gw_uptake: bool = False
     ):
-        check_numba()
         RechargeBase.__init__(self)
         self.snow = snow
         self.interception = interception
@@ -563,7 +561,6 @@ class Berendrecht(RechargeBase):
     _name = "Berendrecht"
 
     def __init__(self) -> None:
-        check_numba()
         RechargeBase.__init__(self)
         self.nparam = 7
 
@@ -715,7 +712,6 @@ class Peterson(RechargeBase):
     _name = "Peterson"
 
     def __init__(self) -> None:
-        check_numba()
         RechargeBase.__init__(self)
         self.nparam = 5
 

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -20,7 +20,7 @@ from scipy.special import (
 )
 
 from .decorators import njit
-from .version import check_numba, check_numba_scipy
+from .version import check_numba_scipy
 
 try:
     from numba import prange
@@ -431,7 +431,6 @@ class HantushWellModel(RfuncBase):
         self.quad = quad  # if quad=True, implicitly uses numba
         # check numba and numba_scipy installation
         if self.quad or self.use_numba:
-            check_numba()
             # turn off use_numba if numba_scipy is not available
             # or there is a version conflict
             if self.use_numba:
@@ -685,7 +684,6 @@ class Hantush(RfuncBase):
         self.quad = quad
         # check numba and numba_scipy installation
         if self.quad or self.use_numba:
-            check_numba()
             # turn off use_numba if numba_scipy is not available
             # or there is a version conflict
             if self.use_numba:

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -167,11 +167,6 @@ def ccf(
         alpha), and the number of samples n used to compute these, respectively. If
         full_output=False, only the CCF is returned.
 
-    Notes
-    -----
-    This method will be significantly faster when Numba is installed. Check out the [
-    Numba project here](https://numba.pydata.org)
-
     Examples
     --------
     >>> ccf = ps.stats.ccf(x, y, bin_method="gaussian")

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -29,7 +29,6 @@ from scipy.stats import norm
 from pastas.typing import ArrayLike
 
 from ..decorators import njit
-from ..version import check_numba
 
 
 def acf(
@@ -199,12 +198,10 @@ def ccf(
     if bin_method == "rectangle":
         if bin_width is None:
             bin_width = 0.5 * dt_mu
-        check_numba()
         c, b = _compute_ccf_rectangle(lags, t_x, x, t_y, y, bin_width)
     elif bin_method == "gaussian":
         if bin_width is None:
             bin_width = 0.25 * dt_mu
-        check_numba()
         c, b = _compute_ccf_gaussian(lags, t_x, x, t_y, y, bin_width)
     elif bin_method == "regular":
         c, b = _compute_ccf_regular(arange(1.0, len(lags) + 1), x, y)

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -32,7 +32,6 @@ from .recharge import Linear
 from .rfunc import Exponential, HantushWellModel, One
 from .timeseries import TimeSeries
 from .utils import validate_name
-from .version import check_numba
 
 logger = getLogger(__name__)
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1405,7 +1405,6 @@ class TarsoModel(RechargeModel):
         rfunc: Optional[RFunc] = Exponential(),
         **kwargs,
     ) -> None:
-        check_numba()
         if oseries is not None:
             if dmin is not None or dmax is not None:
                 msg = "Please specify either oseries or dmin and dmax"

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -6,16 +6,6 @@ __version__ = metadata.version("pastas")
 logger = logging.getLogger(__name__)
 
 
-def check_numba() -> None:
-    try:
-        import_module("numba")
-    except ModuleNotFoundError:
-        logger.warning(
-            "Numba is not installed. Installing Numba is "
-            "recommended for significant speed-ups."
-        )
-
-
 def check_numba_scipy() -> bool:
     try:
         import_module("numba_scipy")
@@ -36,15 +26,13 @@ def check_numba_scipy() -> bool:
     return True
 
 
-def show_versions(lmfit: bool = True, numba: bool = True) -> None:
+def show_versions(lmfit: bool = True) -> None:
     """Method to print the version of dependencies.
 
     Parameters
     ----------
     lmfit: bool, optional
         Print the version of LMfit. Needs to be installed.
-    numba: bool, optional
-        Print the version of Numba. Needs to be installed.
     """
 
     msg = (
@@ -52,7 +40,8 @@ def show_versions(lmfit: bool = True, numba: bool = True) -> None:
         f"NumPy version: {metadata.version('numpy')}\n"
         f"Pandas version: {metadata.version('pandas')}\n"
         f"SciPy version: {metadata.version('scipy')}\n"
-        f"Matplotlib version: {metadata.version('matplotlib')}"
+        f"Matplotlib version: {metadata.version('matplotlib')}\n"
+        f"Numba version: {metadata.version('numba')}"
     )
 
     if lmfit:
@@ -60,14 +49,6 @@ def show_versions(lmfit: bool = True, numba: bool = True) -> None:
         try:
             import_module("lmfit")
             msg += f"{metadata.version('lmfit')}"
-        except ModuleNotFoundError:
-            msg += "Not Installed"
-
-    if numba:
-        msg += "\nNumba version: "
-        try:
-            import_module("numba")
-            msg += f"{metadata.version('numba')}"
         except ModuleNotFoundError:
             msg += "Not Installed"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "matplotlib >= 3.1",
     "pandas >= 1.1",
     "scipy >= 1.8",
+    "numba >= 0.51",
 ]
 
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
@@ -47,7 +48,7 @@ repository = "https://github.com/pastas/pastas"
 documentation = "https://pastas.readthedocs.io/en/latest/"
 
 [project.optional-dependencies]
-full = ["numba >= 0.51", "lmfit >= 1.0.0"]
+full = ["lmfit >= 1.0.0"]
 ci = [
     "pastas[full]",
     "jupyter",


### PR DESCRIPTION
# Short Description
This pull request makes Numba a full on dependency of Pastas. This is because Numba basically always has to be used to make Pastas faster. Additionally, we follow the Numba dependencies for Python and NumPy one on one.

Numba decorators can still be turned off using the `USE_NUMBA` global variable set with `ps.set_use_numba(bool)`.

# Checklist before PR can be merged:
- [x] relates to issue #452 and #451 
- [x] is documented
- [x] black formatted code
- [ ] tests added / passed