### PR TITLE
change meanstress to gain_scale_factor

### DIFF
--- a/doc/concepts/response_functions.ipynb
+++ b/doc/concepts/response_functions.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "# Default Settings\n",
     "cutoff = 0.999\n",
-    "meanstress = 1\n",
+    "gain_scale_factor = 1\n",
     "up = True\n",
     "\n",
     "responses = {}\n",
@@ -150,6 +150,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "pycharm": {
@@ -159,7 +160,7 @@
    "source": [
     "## Parameter settings\n",
     "- **up** : This parameters determines whether the influence of the stress goes up or down, hence a positive or a negative response function. For example, when groundwater pumping is defined as a positive flux, `up=False` because we want the groundwater levels to decrease as a result of pumping.\n",
-    "- **meanstress** : This parameter is used to estimate the initial value of the stationary effect of a stress. Hence the effect when a stress stays at an unit level for infinite amount of time. This parameter is usually referred from the stress time series and does not have to be provided by the user.\n",
+    "- **gain_scale_factor** : This parameter is used to estimate the initial value of the stationary effect of a stress. Hence the effect when a stress stays at an unit level for infinite amount of time. This parameter is usually referred from the stress time series and does not have to be provided by the user.\n",
     "- **cutoff** : This parameter determines for how many time steps the response is calculated. This reduces calculation times as it reduces the length of the array the stress is convolved with. The default value is 0.999, meaning that the response is cutoff after 99.9% of the effect of the stress impulse has occurred. A minimum of length of three times the simulation time step is applied. \n",
     "\n",
     "The default parameter values for each of the response function are as follows:"

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -655,7 +655,7 @@ class HantushWellModel(RfuncBase):
         var_A: float,
         var_b: float,
         cov_Ab: float,
-        r: Optional[float] = 1.0,
+        r: float = 1.0,
     ) -> Union[float, ArrayLike]:
         """Calculate variance of the gain from parameters A and b.
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -67,13 +67,14 @@ class StressModelBase:
         tmax: TimestampType,
         rfunc: Optional[RFunc] = None,
         up: bool = True,
-        gain_scale_factor: float = 1.0,
+        gain_scale_factor: Optional[float] = None,
         cutoff: float = 0.999,
     ) -> None:
         self.name = validate_name(name)
         self.tmin = tmin
         self.tmax = tmax
         self.freq = None
+
         if rfunc is not None:
             if inspect.isclass(rfunc):
                 raise DeprecationWarning(
@@ -304,6 +305,8 @@ class StressModel(StressModelBase):
     gain_scale_factor: float, optional
         the scale factor is used to set the initial value and the bounds of the gain
         parameter, computed as 1 / gain_scale_factor.
+    meanstress: float, optional
+        This argument is deprecated since 0.23. Use `gain_scale_factor` instead.
 
     Examples
     --------
@@ -330,7 +333,13 @@ class StressModel(StressModelBase):
         settings: Optional[Union[dict, str]] = None,
         metadata: Optional[dict] = None,
         gain_scale_factor: Optional[float] = None,
+        meanstress: Optional[float] = None,
     ) -> None:
+        if meanstress is not None:
+            raise DeprecationWarning(
+                "The argument `meanstress` is deprecated since Pastas 0.23. Please "
+                "use the new argument `gain_scale_factor` instead."
+            )
 
         if isinstance(stress, list):
             stress = stress[0]  # TODO Temporary fix Raoul, 2017-10-24
@@ -350,6 +359,8 @@ class StressModel(StressModelBase):
             gain_scale_factor=gain_scale_factor,
             cutoff=cutoff,
         )
+
+        self.gain_scale_factor = gain_scale_factor
         self.freq = stress.settings["freq"]
         self.stress = [stress]
         self.set_init_parameters()
@@ -412,6 +423,7 @@ class StressModel(StressModelBase):
             "up": self.rfunc.up,
             "cutoff": self.rfunc.cutoff,
             "stress": self.dump_stress(series),
+            "gain_scale_factor": self.gain_scale_factor,
         }
         return data
 
@@ -750,6 +762,7 @@ class WellModel(StressModelBase):
             gain_scale_factor=gain_scale_factor,
             cutoff=cutoff,
         )
+
         self.rfunc.set_distances(self.distances.values)
 
         self.stress = stress

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -67,7 +67,7 @@ class StressModelBase:
         tmax: TimestampType,
         rfunc: Optional[RFunc] = None,
         up: bool = True,
-        gain_scale_factor: Optional[float] = None,
+        gain_scale_factor: Optional[float] = 1.0,
         cutoff: float = 0.999,
     ) -> None:
         self.name = validate_name(name)

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -360,7 +360,6 @@ class StressModel(StressModelBase):
             cutoff=cutoff,
         )
 
-        self.gain_scale_factor = gain_scale_factor
         self.freq = stress.settings["freq"]
         self.stress = [stress]
         self.set_init_parameters()
@@ -423,7 +422,6 @@ class StressModel(StressModelBase):
             "up": self.rfunc.up,
             "cutoff": self.rfunc.cutoff,
             "stress": self.dump_stress(series),
-            "gain_scale_factor": self.gain_scale_factor,
         }
         return data
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -67,7 +67,7 @@ class StressModelBase:
         tmax: TimestampType,
         rfunc: Optional[RFunc] = None,
         up: bool = True,
-        gain_scale_factor: Optional[float] = 1.0,
+        gain_scale_factor: float = 1.0,
         cutoff: float = 0.999,
     ) -> None:
         self.name = validate_name(name)


### PR DESCRIPTION
# Short Description

In this PR the meanstress argument in rfuncs and stressmodels is changes to gain_scale_factor. Actually, only the StressModel has this argument.

Funny enough, there is no need to change anything in the loading of pas-files, because the argument was never exported to begin with (I fixed that in this PR as well, exporting through to_dict of StressModel). That made this change very easy to implement. 

# Checklist before PR can be merged:
- [x] closes issue #419 
- [x] is documented
- [x] PEP8 compliant code
- [ ] tests added / passed

