### PR TITLE
Move configuration files to pyproject.toml and delete setup.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 *.so
 
+*.coverage*
+
 pastas.egg-info
 pastas/gui/settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64.0.0", "wheel", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 
@@ -68,7 +68,7 @@ rtd = [
     "sphinx>=3.1, <6.0",
     "sphinxcontrib-bibtex",
     "requests",
-    "numpydoc"
+    "numpydoc",
 ]
 numbascipy = ["numba-scipy >= 0.3.1"]
 
@@ -77,3 +77,7 @@ line-length = 88
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers --durations=0 --cov-report xml:coverage.xml --cov pastas"
+markers = ["notebooks: run notebooks"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = --strict-markers --durations=0 --cov-report xml:coverage.xml --cov pastas 
-markers =
-    notebooks: run notebooks


### PR DESCRIPTION
# Short Description
This PR deletes setup.cfg because it is no longer needed for editable install `pip install -e` since setuptools>=64.0.0 #481
This PR encapsulates pytest.ini to pyproject.toml #482 

# Checklist before PR can be merged:
- [x] closes issue #481 and #482
- [x] is documented
- [x] PEP8 compliant code
