### PR TITLE
Fix to_dict methods for stressmodels

### DIFF
--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1731,7 +1731,7 @@ class ChangeModel(StressModelBase):
 
         return h
 
-    def to_dict(self, series: Optional[bool] = True):
+    def to_dict(self, series: bool = True):
         """Method to export the ChangeModel object.
 
         Returns

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -219,21 +219,8 @@ class StressModelBase:
 
         return self.stress[0].series
 
-    def to_dict(self, series: bool = True) -> dict:
-        """Method to export the StressModel object.
-
-        Returns
-        -------
-        data: dict
-            dictionary with all necessary information to reconstruct the StressModel
-            object.
-        """
-        data = {
-            "stressmodel": self._name,
-            "name": validate_name(self.name, raise_error=True),
-            "stress": self.dump_stress(series),
-        }
-        return data
+    def to_dict(self, **kwargs):
+        """Method to export the stress model object."""
 
     def get_nsplit(self) -> int:
         """Determine in how many time series the contribution can be split."""


### PR DESCRIPTION
# Short Description

Many of the to_dict methods for the different stressmodels were missing or wrong. I added the method everywhere and ensured that the exported keywords and values match those of the _init__ of each method. This ensures the stressmodels are the same when doing ml.copy or exporting/loading pas-files.

# Checklist before PR can be merged:
- [x] closes issue #486
- [x] is documented
- [x] PEP8 compliant code
- [x] tests added / passed
