### PR TITLE
make "class" keyword consistent in to_dict methods

### DIFF
--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -100,18 +100,30 @@ def _load_model(data: dict) -> Model:
 
     # Add transform
     if "transform" in data.keys():
-        transform = getattr(ps.transform, data["transform"].pop("transform"))
+        # Todo Deal with old files. Remove in pastas 1.0
+        if "transform" in data["transform"].keys():
+            data["transform"]["class"] = data["transform"].pop("transform")
+
+        transform = getattr(ps.transform, data["transform"].pop("class"))
         transform = transform(**data["transform"])
         ml.add_transform(transform)
 
     # Add noisemodel if present
     if "noisemodel" in data.keys():
-        n = getattr(ps.noisemodels, data["noisemodel"]["type"])()
+        # Todo Deal with old files. Remove in pastas 1.0
+        if "type" in data["noisemodel"].keys():
+            data["noisemodel"]["class"] = data["noisemodel"].pop("type")
+
+        n = getattr(ps.noisemodels, data["noisemodel"].pop("class"))()
         ml.add_noisemodel(n)
 
     # Add fit object to the model
     if "fit" in data.keys():
-        fit = getattr(ps.solver, data["fit"].pop("name"))
+        # Todo Deal with old files. Remove in pastas 1.0
+        if "name" in data["fit"].keys():
+            data["fit"]["class"] = data["fit"].pop("name")
+
+        fit = getattr(ps.solver, data["fit"].pop("class"))
         ml.fit = fit(ml=ml, **data["fit"])
 
     # Add parameters, use update to maintain correct order
@@ -127,8 +139,12 @@ def _load_model(data: dict) -> Model:
 
 
 def _load_stressmodel(ts, data):
+    # Todo Deal with old files. Remove in pastas 1.0
+    if "stressmodel" in ts.keys():
+        ts["class"] = ts.pop("stressmodel")
+
     # TODO Deal with old StressModel2 files for version 0.22.0. Remove in 0.23.0.
-    if ts["stressmodel"] == "StressModel2":
+    if ts["class"] == "StressModel2":
         msg = (
             "StressModel2 is removed since Pastas 0.22.0 and is replaced by the "
             "RechargeModel using a Linear recharge model. Make sure to save "
@@ -140,7 +156,7 @@ def _load_stressmodel(ts, data):
         raise NotImplementedError(msg)
 
     # TODO Deal with old parameter value b in HantushWellModel: b_new = np.log(b_old)
-    if (ts["stressmodel"] == "WellModel") and (
+    if (ts["class"] == "WellModel") and (
         version.parse(data["file_info"]["pastas_version"]) < version.parse("0.22.0")
     ):
         logger.warning(
@@ -169,8 +185,8 @@ def _load_stressmodel(ts, data):
             ts["recharge"] = recharge_kwargs
 
     # Create and add stress model
-    stressmodel = getattr(ps.stressmodels, ts["stressmodel"])
-    ts.pop("stressmodel")
+    stressmodel = getattr(ps.stressmodels, ts.pop("class"))
+
     if "rfunc" in ts.keys():
         rfunc_class = ts["rfunc"].pop("class")  # Determine response class
         ts["rfunc"] = getattr(ps.rfunc, rfunc_class)(**ts["rfunc"])

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -90,7 +90,9 @@ class NoiseModelBase:
         self.parameters.loc[name, "vary"] = value
 
     def to_dict(self) -> dict:
-        return {"type": self._name}
+        """Method to return a dict to store the noise model"""
+        data = {"class": self._name, "norm": self.norm}
+        return data
 
     @staticmethod
     def weights(res, p) -> int:
@@ -190,6 +192,11 @@ class NoiseModel(NoiseModelBase):
         if self.norm:
             w *= np.exp(1.0 / (2.0 * odelt.size) * np.sum(np.log(1.0 - exp)))
         return Series(data=w, index=res.index, name="noise_weights")
+
+    def to_dict(self) -> dict:
+        """Method to return a dict to store the noise model"""
+        data = {"class": self._name, "norm": self.norm}
+        return data
 
 
 class ArmaModel(NoiseModelBase):

--- a/pastas/solver.py
+++ b/pastas/solver.py
@@ -423,7 +423,7 @@ class BaseSolver:
 
     def to_dict(self) -> dict:
         data = {
-            "name": self._name,
+            "class": self._name,
             "pcov": self.pcov,
             "nfev": self.nfev,
             "obj_func": self.obj_func,

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -379,7 +379,7 @@ class StressModel(StressModelBase):
 
         """
         data = {
-            "stressmodel": self._name,
+            "class": self._name,
             "rfunc": self.rfunc.to_dict(),
             "name": self.name,
             "up": self.rfunc.up,
@@ -488,7 +488,7 @@ class StepModel(StressModelBase):
 
         """
         data = {
-            "stressmodel": self._name,
+            "class": self._name,
             "tstart": self.tstart,
             "name": self.name,
             "rfunc": self.rfunc.to_dict(),
@@ -587,7 +587,7 @@ class LinearTrend(StressModelBase):
 
         """
         data = {
-            "stressmodel": self._name,
+            "class": self._name,
             "start": self.start,
             "end": self.end,
             "name": self.name,
@@ -639,7 +639,7 @@ class Constant(StressModelBase):
             object.
         """
         data = {
-            "stressmodel": self._name,
+            "class": self._name,
             "name": self.name,
             "initial": self.initial,
         }
@@ -938,7 +938,7 @@ class WellModel(StressModelBase):
             object.
         """
         data = {
-            "stressmodel": self._name,
+            "class": self._name,
             "stress": self.dump_stress(series),
             "rfunc": self.rfunc.to_dict(),
             "name": self.name,
@@ -1375,7 +1375,7 @@ class RechargeModel(StressModelBase):
 
         """
         data = {
-            "stressmodel": self._name,
+            "class": self._name,
             "prec": self.prec.to_dict(series=series),
             "evap": self.evap.to_dict(series=series),
             "rfunc": self.rfunc.to_dict(),

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -129,7 +129,7 @@ class ThresholdTransform:
 
     def to_dict(self) -> dict:
         data = {
-            "transform": self._name,
+            "class": self._name,
             "value": self.value,
             "vmin": self.vmin,
             "vmax": self.vmax,


### PR DESCRIPTION
# Short Description

The changes in this PR make the use of the keyword "class" consistent in all to_dict methods through Pastas. See also issue #495 about this. Everything is backward compatible for pastas 0.23. For 1.0, only models saved with pastas 0.23 will work like all other changes.

# Checklist before PR can be merged:
- [x] closes issue #495
- [x] is documented
- [x] PEP8 compliant code
- [x] tests added / passed
