### PR TITLE
remove deprecations from stressmodels and rfunc

### DIFF
--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -4,6 +4,7 @@
 from logging import getLogger
 
 import numpy as np
+from numpy import pi
 from pandas import DataFrame
 from scipy.integrate import quad
 from scipy.interpolate import interp1d
@@ -18,7 +19,6 @@ from scipy.special import (
     k1,
     lambertw,
 )
-from numpy import pi
 
 from .decorators import njit, latexfun
 from .version import check_numba_scipy
@@ -60,13 +60,6 @@ class RfuncBase:
         **kwargs,
     ) -> None:
         self.up = up
-        if "meanstress" in kwargs.keys():
-            logger.warning(
-                "The mean_stress argument is deprecated and will throw an error "
-                "in Pastas 1.0. Please use the `gain_scale_factor` argument instead."
-            )
-            gain_scale_factor = kwargs["meanstress"]
-
         self.gain_scale_factor = gain_scale_factor
         self.cutoff = cutoff
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -14,9 +14,7 @@ See Also
 pastas.model.Model.add_stressmodel
 """
 
-import inspect
 from logging import getLogger
-from importlib.metadata import version
 
 # Type Hinting
 from typing import List, Optional, Tuple, Union
@@ -26,7 +24,6 @@ from pandas import DataFrame, Series, Timedelta, Timestamp, concat, date_range
 from scipy.signal import fftconvolve
 
 from pastas.typing import ArrayLike, Model, Recharge, RFunc, TimestampType
-
 from .decorators import njit, set_parameter
 from .recharge import Linear
 from .rfunc import Exponential, HantushWellModel, One
@@ -75,12 +72,6 @@ class StressModelBase:
         self.freq = None
 
         if rfunc is not None:
-            if inspect.isclass(rfunc):
-                raise DeprecationWarning(
-                    "Response functions should be added to a stress model as an "
-                    "instance (e.g., ps.One()), and not as a class (e.g., ps.One). "
-                    "Please provide an instance of the response function."
-                )
             rfunc._update_rfunc_settings(up=up, gain_scale_factor=gain_scale_factor)
         self.rfunc = rfunc
 
@@ -252,9 +243,6 @@ class StressModel(StressModelBase):
     up: bool or None, optional
         True if response function is positive (default), False if negative. None if
         you don't want to define if response is positive or negative.
-    cutoff: float, optional
-        This argument is deprecated since 0.23. Directly provide this to directly to
-        the response function instance (e.g., ps.Gamma(cutoff=0.999).
     settings: dict or str, optional
         The settings of the stress. This can be a string referring to a predefined
         settings dict, or a dict with the settings to apply. Refer to the docstring
@@ -265,8 +253,6 @@ class StressModel(StressModelBase):
     gain_scale_factor: float, optional
         the scale factor is used to set the initial value and the bounds of the gain
         parameter, computed as 1 / gain_scale_factor.
-    meanstress: float, optional
-        This argument is deprecated since 0.23. Use `gain_scale_factor` instead.
 
     Examples
     --------
@@ -289,21 +275,10 @@ class StressModel(StressModelBase):
         rfunc: RFunc,
         name: str,
         up: bool = True,
-        cutoff=None,
         settings: Optional[Union[dict, str]] = None,
         metadata: Optional[dict] = None,
         gain_scale_factor: Optional[float] = None,
-        meanstress: Optional[float] = None,
     ) -> None:
-        raise_deprecations(meanstress=meanstress, cutoff=cutoff)
-
-        if isinstance(stress, list):
-            logger.warning(
-                "providing a stress as list is deprecated and will results "
-                "in an Error in Pastas 1.0."
-            )
-            stress = stress[0]  # TODO Remove in Pastas 1.0
-
         stress = TimeSeries(stress, settings=settings, metadata=metadata)
 
         StressModelBase.__init__(
@@ -405,9 +380,6 @@ class StepModel(StressModelBase):
         ps.rfunc.One(), an instant effect.
     up: bool, optional
         Force a direction of the step. Default is None.
-    cutoff: float, optional
-        This argument is deprecated since 0.23. Directly provide this to directly to
-        the response function instance (e.g., ps.Gamma(cutoff=0.999).
 
     Notes
     -----
@@ -424,10 +396,7 @@ class StepModel(StressModelBase):
         name: str,
         rfunc: Optional[RFunc] = None,
         up: bool = True,
-        cutoff=None,
     ) -> None:
-        raise_deprecations(cutoff=cutoff)
-
         if rfunc is None:
             rfunc = One()
         StressModelBase.__init__(
@@ -663,9 +632,6 @@ class WellModel(StressModelBase):
         whether a positive stress has an increasing or decreasing effect on the model,
         by default False, in which case positive stress lowers e.g., the groundwater
         level.
-    cutoff: float, optional
-        This argument is deprecated since 0.23. Directly provide this to directly to
-        the response function instance (e.g., ps.Gamma(cutoff=0.999).
     settings: str, list of dict, optional
         settings of the time series, by default "well".
     sort_wells: bool, optional
@@ -692,12 +658,11 @@ class WellModel(StressModelBase):
         name: str,
         distances: ArrayLike,
         up: bool = False,
-        cutoff=None,
         settings: str = "well",
         sort_wells: bool = True,
         metadata: Optional[list] = None,
     ) -> None:
-        raise_deprecations(cutoff=cutoff)
+
         if not isinstance(rfunc, HantushWellModel):
             raise NotImplementedError(
                 "WellModel only supports the rfunc HantushWellModel!"
@@ -1016,9 +981,6 @@ class RechargeModel(StressModelBase):
     temp: pandas.Series, optional
         pandas.Series with pandas.DatetimeIndex containing the temperature series.
         It depends on the recharge model is this argument is required or not.
-    cutoff: float, optional
-        This argument is deprecated since 0.23. Directly provide this to directly to
-        the response function instance (e.g., ps.Gamma(cutoff=0.999).
     settings: list of dicts or str, optional
         The settings of the precipitation and evaporation time series, in this order.
         This can be a string referring to a predefined settings dict, or a dict with
@@ -1064,7 +1026,6 @@ class RechargeModel(StressModelBase):
         name: str = "recharge",
         recharge: Optional[Recharge] = None,
         temp: Optional[Series] = None,
-        cutoff=None,
         settings: Tuple[Union[str, dict], Union[str, dict], Union[str, dict]] = (
             "prec",
             "evap",
@@ -1072,7 +1033,6 @@ class RechargeModel(StressModelBase):
         ),
         metadata: Optional[Tuple[dict, dict, dict]] = (None, None, None),
     ) -> None:
-        raise_deprecations(cutoff=cutoff)
         if rfunc is None:
             rfunc = Exponential()
 
@@ -1600,9 +1560,6 @@ class ChangeModel(StressModelBase):
     up: bool or None, optional
         True if response function is positive (default), False if negative. None if
         you don't want to define if response is positive or negative.
-    cutoff: float, optional
-        This argument is deprecated since 0.23. Directly provide this to directly to
-        the response function instance (e.g., ps.Gamma(cutoff=0.999).
     settings: dict or str, optional
         the settings of the stress. This can be a string referring to a predefined
         settings dict, or a dict with the settings to apply. Refer to the docstring
@@ -1626,19 +1583,9 @@ class ChangeModel(StressModelBase):
         name: str,
         tchange: Union[str, TimestampType],
         up: bool = True,
-        cutoff=None,
         settings: Optional[Union[dict, str]] = None,
         metadata: Optional[dict] = None,
     ) -> None:
-        raise_deprecations(cutoff=cutoff)
-
-        if isinstance(stress, list):
-            logger.warning(
-                "providing a stress as list is deprecated and will results "
-                "in an Error in Pastas 1.0."
-            )
-            stress = stress[0]  # TODO Remove in Pastas 1.0
-
         stress = TimeSeries(stress, settings=settings, metadata=metadata)
 
         StressModelBase.__init__(
@@ -1648,11 +1595,6 @@ class ChangeModel(StressModelBase):
             tmin=stress.series.index.min(),
             tmax=stress.series.index.max(),
         )
-        if inspect.isclass(rfunc1) or inspect.isclass(rfunc2):
-            raise DeprecationWarning(
-                "Response functions should be provided as an instance (e.g., ps.One()),"
-                " not as a class (e.g., ps.One). Please provide an instance."
-            )
 
         rfunc1._update_rfunc_settings(up=up)
         self.rfunc1 = rfunc1
@@ -1754,25 +1696,3 @@ class ChangeModel(StressModelBase):
             "up": self.rfunc1.up,
         }
         return data
-
-
-def StressModel2(*args, **kwargs):
-    msg = (
-        "StressModel2 is removed in Pastas 0.23 and replaced by the RechargeModel "
-        "stress model. Use ps.RechargeModel(prec, evap, recharge=ps.rch.Linear) for "
-        "the same stress model in future codes."
-    )
-    logger.error(msg)
-
-
-def raise_deprecations(meanstress=None, cutoff=None):
-    if meanstress is not None:
-        raise DeprecationWarning(
-            "The argument `meanstress` is deprecated since Pastas 0.23. Please "
-            "use the new argument `gain_scale_factor` instead."
-        )
-    if cutoff is not None:
-        raise DeprecationWarning(
-            "The argument `cutoff` is deprecated since Pastas 0.23. Please "
-            "apply this directly to the response function (e.g., ps.Gamma(cutoff=0.99))"
-        )


### PR DESCRIPTION
# Short Description

This PR removes all deprecated things in stressmodels.py and rfunc.py

# Checklist before PR can be merged:
- [ ] closes issue #411, #360, #419
- [ ] is documented
- [ ] PEP8 compliant code
- [ ] tests added / passed
- [ ] Example Notebook (for new features)
