### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,9 @@ rtd = [
     "numpydoc",
     "sphinx-design",
 ]
-dev = ["tox", "pastas[formatting,linting,ci,rtd]"]
+workshop = ["pastas[full]", "hydropandas>=0.7.0", "jupyterlab"]
+dev = ["tox", "pastas[formatting,linting,ci,rtd,full]"]
 numbascipy = ["numba-scipy >= 0.3.1"]
-
 
 [tool.setuptools.dynamic]
 version = { attr = "pastas.version.__version__" }


### PR DESCRIPTION
Create an optional dependency in the pyproject.toml for courses/workshops. We release a new version of pastas when we give a workshop anyway so I think this makes installing easier. So attendees of workshops only have to install pastas using:
pip install pastas[workshop] where the optional dependencies are (currently): pastas[full], hydropandas and jupyterlab

# Checklist before PR can be merged:
- [x] closes issue #539 