### PR TITLE
Update types.py to support Matplotlib <v3.4

### DIFF
--- a/doc/examples/example_uncertainty.py
+++ b/doc/examples/example_uncertainty.py
@@ -7,7 +7,7 @@ ps.set_log_level("ERROR")
 
 # read observations and create the time series model
 obs = pd.read_csv("data/head_nb1.csv", index_col=0, parse_dates=True).squeeze("columns")
-ml = ps.Model(obs, name="groundwater head")
+ml = ps.Model(obs, name="groundwater_head")
 
 # read weather data and create stressmodel
 rain = pd.read_csv("data/rain_nb1.csv", index_col=0, parse_dates=True).squeeze(

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -17,7 +17,8 @@ from logging import getLogger
 # Type Hinting
 from typing import Optional
 
-from numpy import abs, average, log, nan, sqrt
+from numpy import average, log, nan, sqrt
+from numpy import abs as npabs
 from pandas import Series
 
 from pastas.stats.core import _get_weights, mean, std, var
@@ -87,7 +88,7 @@ def mae(
         return nan
 
     w = _get_weights(err, weighted=weighted, max_gap=max_gap)
-    return (w * abs(err.to_numpy())).sum()
+    return (w * npabs(err.to_numpy())).sum()
 
 
 def rmse(

--- a/pastas/typing/__init__.py
+++ b/pastas/typing/__init__.py
@@ -8,7 +8,6 @@ from .types import (
     Model,
     NoiseModel,
     Recharge,
-    Reservoir,
     RFunc,
     Solver,
     StressModel,

--- a/pastas/typing/types.py
+++ b/pastas/typing/types.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
 
 # External libraries
 # Matplotlib
-from matplotlib.axes._base import _AxesBase
-from matplotlib.figure import FigureBase
+from matplotlib.axes import Axes as MatplotlibAxes
+from matplotlib.figure import Figure as MatplotlibFigure
 
 # Numpy
 from numpy.typing import ArrayLike as NumpyArrayLike
@@ -15,8 +15,8 @@ from numpy.typing import ArrayLike as NumpyArrayLike
 from pandas import Timestamp
 
 # External Types
-Axes = TypeVar("Axes", bound=_AxesBase)  # Matplotlib Axes
-Figure = TypeVar("Figure", bound=FigureBase)  # Matplotlib Figure
+Axes = TypeVar("Axes", bound=MatplotlibAxes)  # Matplotlib Axes
+Figure = TypeVar("Figure", bound=MatplotlibFigure)  # Matplotlib Figure
 ArrayLike = TypeVar("ArrayLike", bound=NumpyArrayLike)  # Array Like (NumPy based)
 
 # Internal library

--- a/pastas/typing/types.py
+++ b/pastas/typing/types.py
@@ -26,14 +26,13 @@ if TYPE_CHECKING:  # https://mypy.readthedocs.io/en/latest/runtime_troubles.html
 # Internal Types
 TimestampType = TypeVar("TimestampType", bound=Union[str, Timestamp])  # Tmin or Tmax
 Model = TypeVar("Model", bound="ps.Model")  # Model
-TimeSeries = TypeVar("TimeSeries", bound="ps.TimeSeries")  # Time Series
+TimeSeries = TypeVar("TimeSeries", bound="ps.timeseries.TimeSeries")  # Time Series
 StressModel = TypeVar(
     "StressModel", bound="ps.stressmodels.StressModelBase"
 )  # Stress Model
 NoiseModel = TypeVar("NoiseModel", bound="ps.noisemodels.NoiseModelBase")  # Noise Model
 Solver = TypeVar("Solver", bound="ps.solver.BaseSolver")  # Base Solver
 Recharge = TypeVar("Recharge", bound="ps.recharge.RechargeBase")  # Recharge Base
-Reservoir = TypeVar("Reservoir", bound="ps.reservoir.ReservoirBase")  # Reservoir Base
 CallBack = TypeVar("CallBack", bound=Any)  # Callback
 Function = Callable[..., Any]  # Function (e.g. Objective Function)
 RFunc = TypeVar("RFunc", bound="ps.rfunc.RfuncBase")  # rFunc Base

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -4,7 +4,7 @@ from platform import python_version
 
 logger = logging.getLogger(__name__)
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 def check_numba_scipy() -> bool:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -134,3 +134,8 @@ def test_get_output_series_arguments(ml) -> None:
 def test_model_sim_w_nans_error(ml_no_settings):
     with pytest.raises(ValueError) as e_info:
         ml_no_settings.solve()
+
+
+def test_modelstats(ml) -> None:
+    ml.solve()
+    ml.stats.summary()


### PR DESCRIPTION
# Short Description
Matplotlib only has `FigureBase` since >v3.3 so this gives this would give an `ImportError` if the Matploblib version of the user was <=v3.3. If we want to keep supporting: https://github.com/pastas/pastas/blob/730251140dab2392b88dc15050f6c2ed006bf4b9/pyproject.toml#L25
this small change has to be made.

# Checklist before PR can be merged:
- [x] closes part of issue #480 