### PR TITLE
Fix issue #564

### DIFF
--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1412,7 +1412,6 @@ class TarsoModel(RechargeModel):
             rfunc = Exponential()
         if not isinstance(rfunc, Exponential):
             raise NotImplementedError("TarsoModel only supports rfunc Exponential!")
-        self.oseries = oseries
         self.dmin = dmin
         self.dmax = dmax
         super().__init__(prec=prec, evap=evap, rfunc=rfunc, **kwargs)
@@ -1483,7 +1482,6 @@ class TarsoModel(RechargeModel):
         data = super().to_dict(series)
         data["dmin"] = self.dmin
         data["dmax"] = self.dmax
-        data["oseries"] = self.oseries
         return data
 
     @staticmethod


### PR DESCRIPTION
# Short Description
This pull request fixes issue 564 by not saving the oseries variable in the TarsoModel anymore. This variable is only used to determine dmin and dmax, which are stored in TarsoModel. So there is no need to also keep a reference to oseries. 

# Checklist before PR can be merged:
- [x] closes issue #564
- [ ] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [ ] type hints for functions and methods
- [ ] tests added / passed
- [ ] Example Notebook (for new features)
- [ ] Remove output for all notebooks with changes
