### PR TITLE
Codacy coverage upload, auto-assign pr and flake8 update

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,15 @@
+# .github/workflows/auto-author-assign.yml
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,30 +68,8 @@ jobs:
       - name: Test
         run: tox -e ${{ matrix.toxenv }} --skip-pkg-install
 
-      - name: Store coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage.xml
-          if-no-files-found: ignore
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
-        with:
-          check-latest: true
-
-      - name: Get coverage
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage
-
       - name: Run codacy-coverage-reporter
-        if: ${{ github.repository == 'pastas/pastas' && success() }}
+        if: ${{ matrix.toxenv == 'notebooks' && github.repository == 'pastas/pastas' && success() }}
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,8 +44,7 @@ project? Check out the :doc:`Developers <developers/index>` section.
         Find an overview of scientific peer-reviewed studies that used Pastas.
 
     .. grid-item-card:: More Pastas
-        :link: about/organisation
-        :link-type: doc
+        :link: https://github.com/pastas/
 
         Find out more useful resources developed by the Pastas community!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ legacy_tox_ini = """
     basepython = python3.9
     extras = linting
     commands =
-            flake8 pastas --count --exit-zero --max-line-length=88 --show-source
-            flake8 pastas --count --exit-zero --max-line-length=88 --statistics
+            flake8 pastas --count --show-source --exit-zero --max-line-length=88 --ignore=E203,W503,W504
+            flake8 pastas --count --exit-zero --max-line-length=88 --statistics --ignore=E203,W503,W504
 
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pytesting = ["pytest>=7", "pytest-cov", "pytest-sugar"]
 ci = [
     "pastas[full,pytesting]",
     "jupyter",
-    "codacy-coverage",
+    "coverage",
     "corner",
     "emcee",
     "tqdm",
@@ -83,7 +83,7 @@ line-length = 88
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --durations=0 --cov-report xml:coverage.xml --cov pastas"
+addopts = "--strict-markers --durations=0"
 markers = ["notebooks: run notebooks"]
 
 [tool.tox]
@@ -99,10 +99,11 @@ legacy_tox_ini = """
             pytest tests -m "not notebooks"
 
     [testenv:notebooks]
-    description = run unit tests
+    description = run all unit tests and obtain coverage
     extras = ci
     commands =
-            pytest tests
+            coverage run -m pytest tests
+            coverage xml
 
     [testenv:format]
     description = run formatters
@@ -117,7 +118,7 @@ legacy_tox_ini = """
     basepython = python3.9
     extras = linting
     commands =
-            flake8 pastas --count --show-source --exit-zero --max-line-length=88
+            flake8 pastas --count --exit-zero --max-line-length=88 --show-source
             flake8 pastas --count --exit-zero --max-line-length=88 --statistics
 
 """


### PR DESCRIPTION
# Short Description
Sinced #515 the codacy coverage report is uploaded from the GitHub CI test that takes the longest. This was a temporary fix because the if statements in the ci.yml did not work properly. Also, it is not a very robust solution if we introduce a CI test that takes longer (e.g. readthedocs #458). With this change the codacy coverage report is specifically created in the _notebooks_ toxenv in the GitHub CI _Test suite for Jupyter Notebooks_.