### PR TITLE
fix #575 duplicate columns in plots.compare()

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -45,7 +45,6 @@ def test_contributions_pie(ml) -> None:
 
 def test_compare(ml) -> None:
     ml2 = ml.copy()
-    ml2.name = "Test_Model2"
     models = [ml, ml2]
     _ = compare(models)
 


### PR DESCRIPTION
# Short Description
Prevent duplicate modelnames from creating extra columns in comparison plots

# Checklist before PR can be merged:
- [x] closes issue #575
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed