### PR TITLE
fix #549 stderr formatting

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -25,7 +25,7 @@ from pandas import (
 # Internal Pastas
 from pastas.decorators import get_stressmodel
 from pastas.io.base import _load_model, dump
-from pastas.modelplots import Plotting
+from pastas.modelplots import Plotting, _table_formatter_stderr
 from pastas.modelstats import Statistics
 from pastas.noisemodels import NoiseModel
 from pastas.solver import LeastSquares
@@ -795,7 +795,7 @@ class Model:
         if solver is not None:
             self.fit = solver
             self.fit.set_model(self)
-        # Create the default solver is None is provided or already present
+        # Create the default solver if None is provided or already present
         elif self.fit is None:
             self.fit = LeastSquares()
             self.fit.set_model(self)
@@ -1741,7 +1741,9 @@ class Model:
 
         parameters = self.parameters.loc[:, ["optimal", "stderr", "initial", "vary"]]
         stderr = parameters.loc[:, "stderr"] / parameters.loc[:, "optimal"]
-        parameters.loc[:, "stderr"] = stderr.abs().apply("±{:.2%}".format)
+        parameters.loc[:, "stderr"] = "±" + stderr.abs().apply(
+            _table_formatter_stderr, na_rep="nan"
+        )
 
         # Determine the width of the fit_report based on the parameters
         width = len(parameters.to_string().split("\n")[1])

--- a/pastas/plots.py
+++ b/pastas/plots.py
@@ -924,7 +924,7 @@ class TrackSolve:
         return fig.axes
 
 
-def _table_formatter_params(s: float) -> str:
+def _table_formatter_params(s: float, na_rep: str = "") -> str:
     """Internal method for formatting parameters in tables in Pastas plots.
 
     Parameters
@@ -938,7 +938,7 @@ def _table_formatter_params(s: float) -> str:
         float formatted as str.
     """
     if np.isnan(s):
-        return ""
+        return na_rep
     elif np.floor(np.log10(np.abs(s))) <= -2:
         return f"{s:.2e}"
     elif np.floor(np.log10(np.abs(s))) > 5:
@@ -947,7 +947,7 @@ def _table_formatter_params(s: float) -> str:
         return f"{s:.2f}"
 
 
-def _table_formatter_stderr(s: float) -> str:
+def _table_formatter_stderr(s: float, na_rep: str = "") -> str:
     """Internal method for formatting stderrs in tables in Pastas plots.
 
     Parameters
@@ -961,7 +961,7 @@ def _table_formatter_stderr(s: float) -> str:
         float formatted as str.
     """
     if np.isnan(s):
-        return ""
+        return na_rep
     elif np.floor(np.log10(np.abs(s))) <= -4:
         return f"{s * 100.:.2e}%"
     elif np.floor(np.log10(np.abs(s))) > 3:


### PR DESCRIPTION
- add na_rep to _table_formatter_stderr, default  is blank (for tables in plots) but use "nan" for fit_report.
- use stderr formatter in fit_report

# Short Description
use existing stderr formatter in fit_report to avoid extremely large values being represented in normal notation.

# Checklist before PR can be merged:
- [x] closes issue #549 
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
