### PR TITLE
Add (Pandas) resample wrapper function to timeseries_utils

### DIFF
--- a/doc/examples/prepare_timeseries.ipynb
+++ b/doc/examples/prepare_timeseries.ipynb
@@ -299,7 +299,7 @@
    "metadata": {},
    "source": [
     "### Creating equidistant time series for fluxes\n",
-    "There are several methods in Pandas to create equidistant series. A flux describes a measured or logged quantity over a period of time, ressulting in a pandas Series. In this series, each flux is asssigned a timestamp in the index. In Pastas, we assume the timestamp is at _the end of the period_ that belongs to each measurement. This means that the precipitation of march 5 2022 gets the timestamp '2022-03-06 00:00:00' (which can be counter-intuitive, as the index is now a day later). Therefore, when using Pandas resample methods, we add two parameters: closed='right' and label='right'."
+    "There are several methods in Pandas to create equidistant series. A flux describes a measured or logged quantity over a period of time, ressulting in a pandas Series. In this series, each flux is asssigned a timestamp in the index. In Pastas, we assume the timestamp is at _the end of the period_ that belongs to each measurement. This means that the precipitation of march 5 2022 gets the timestamp '2022-03-06 00:00:00' (which can be counter-intuitive, as the index is now a day later). Therefore, when using Pandas resample methods, we add two parameters: closed='right' and label='right'. So given this series of precipitation in mm:"
    ]
   },
   {
@@ -314,9 +314,81 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9277882e",
+   "metadata": {},
+   "source": [
+    "using `\"right\"` would yield:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "90fffac6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series.resample(\"12H\", closed=\"right\", label=\"right\").sum()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "4e8f4e47",
+   "metadata": {},
+   "source": [
+    "which is logical because over the first 12 hours (between 01-01 00:00:00 and 01-01 12:00:00) 3mm of precipitation fell. However, using `\"left\"` would yield:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47536431",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series.resample(\"12H\", closed=\"left\", label=\"left\").sum()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "583f24ad",
+   "metadata": {},
+   "source": [
+    "Pastas helps users with a simple wrapper around the pandas resample function with setting \"right\" keyword arguments for `closed` and `label`:\n",
+    "\n",
+    "`resampler = pastas.timeseries_utils.resample(series, freq)`. \n",
+    "\n",
+    "When this resampler is return series can easily be interpolated, summed or averaged using all [resample methods](https://pandas.pydata.org/docs/reference/resampling.html) available in the Pandas library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53fb5987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ps.timeseries_utils.resample(\n",
+    "    series, \"12H\"\n",
+    ").sum()  # gives the same as series.resample(\"12H\", closed=\"right\", label=\"right\").sum()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e12fb4a6",
+   "metadata": {},
+   "source": [
+    "The resample-method of pandas basically is a groupby-method. This creates problems when there is not a single measurement in each group / bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f911d9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,11 +396,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "871598bf",
    "metadata": {},
    "source": [
-    "The resample-method of pandas basically is a groupby-method. This creates problems when there is not a single measurement in each group. This is demponstrated by the NaN at 2000-01-01 18:00:00. Also when there are two values in a group, these are averaged, even though one of the values only counts for one hour, and the other for 6 hours. This is demonstrated by the value of 3.5 at 2000-01-02 00:00:00.\n",
+    "This is demponstrated by the NaN at 2000-01-01 18:00:00. Also when there are two values in a group, these are averaged, even though one of the values only counts for one hour, and the other for 6 hours. This is demonstrated by the value of 3.5 at 2000-01-02 00:00:00.\n",
     "\n",
     "Because of these problems there is a method called 'timestep_weighted_resample' in Pastas. This method assumes the index is at the end of the period that belongs to each measurement, just like the rest of Pastas. Using this assumption, the method can calculate a new series, using an overlapping period weighted average:"
    ]
@@ -340,7 +413,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_index = pd.date_range(series.index[0], series.index[-1], freq=\"6H\")\n",
+    "new_index = pd.date_range(series.index[0], series.index[-1], freq=\"12H\")\n",
     "ps.ts.timestep_weighted_resample(series, new_index)"
    ]
   },
@@ -1018,7 +1091,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:20:46) \n[GCC 9.4.0]"
+   "version": "3.9.15"
   },
   "vscode": {
    "interpreter": {

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -8,7 +8,7 @@ from pandas import Series
 from pandas.tseries.frequencies import to_offset
 
 from .rcparams import rcParams
-from .timeseries_utils import _get_dt, _get_time_offset, _infer_fixed_freq
+from .timeseries_utils import _get_dt, _get_time_offset, _infer_fixed_freq, resample
 from .utils import validate_name
 
 logger = getLogger(__name__)
@@ -327,20 +327,17 @@ class TimeSeries:
         if self.settings["time_offset"] > pd.Timedelta(0):
             series = series.shift(-1, freq=self.settings["time_offset"])
 
-        # Provide some standard pandas arguments for all options
-        kwargs = {"label": "right", "closed": "right"}
-
         success = True
         if method == "mean":
-            series = series.resample(freq, **kwargs).mean()
+            series = resample(series, freq).mean()
         elif method == "drop":
-            series = series.resample(freq, **kwargs).mean().dropna()
+            series = resample(series, freq).mean().dropna()
         elif method == "sum":
-            series = series.resample(freq, **kwargs).sum()
+            series = resample(series, freq).sum()
         elif method == "min":
-            series = series.resample(freq, **kwargs).min()
+            series = resample(series, freq).min()
         elif method == "max":
-            series = series.resample(freq, **kwargs).max()
+            series = resample(series, freq).max()
         else:
             success = False
 

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -467,9 +467,9 @@ def pandas_equidistant_nearest(
     Parameters
     ----------
     series : str
-        _description_
+        time series.
     freq : str
-        _description_
+        frequency string.
     tolerance : str, optional
         frequency type string (e.g. '7D') specifying maximum distance between original
         and new labels for inexact matches.

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -524,21 +524,25 @@ def pandas_equidistant_asfreq(series: Series, freq: str) -> Series:
 def resample(
     series: Series, freq: str, closed: str = "right", label: str = "right", **kwargs
 ) -> Resampler:
-    """Wrapper around the pandas resample function with logical some Pastas defaults.
-       In Pastas, we assume the timestamp is at the end of the period that
-       belongs to each measurement. For more information on this read the
-       example notebook on preprocessing time series.
+    """Resample time-series data.
+
+    Convenience method for frequency conversion and resampling of time series.
+    This function is a wrapper around Pandas' resample function with some
+    logical Pastas defaults. In Pastas, we assume the timestamp is at the end
+    of the period that belongs to each measurement. For more information on
+    this read the example notebook on preprocessing time series.
 
     Parameters
     ----------
-    series : Series
-        time series
+    series : pandas Series
+        Time series. The index must be a datetime-like index
+        (`DatetimeIndex`, `PeriodIndex`, or `TimedeltaIndex`).
     freq : str
-        frequency string
+        Frequency string.
     closed: str, default 'right'
-        which side/end of bin interval is closed
+        Which side/end of bin interval is closed.
     label: str, default 'right'
-        which bin edge label to label bucket with
+        Which bin edge label to label bucket with.
     **kwargs: dict
 
     Returns

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -554,4 +554,4 @@ def resample(
 
     """
 
-    return series.copy().resample(freq, closed=closed, label=label, **kwargs)
+    return series.resample(freq, closed=closed, label=label, **kwargs)

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import numpy as np
 from pandas import Index, Series, Timedelta, Timestamp, api, date_range, infer_freq
+from pandas.core.resample import Resampler
 from pandas.tseries.frequencies import to_offset
 from scipy import interpolate
 
@@ -518,3 +519,35 @@ def pandas_equidistant_asfreq(series: Series, freq: str) -> Series:
         .squeeze()
     )
     return spandas
+
+
+def resample(
+    series: Series, freq: str, closed: str = "right", label: str = "right", **kwargs
+) -> Resampler:
+    """Wrapper around the pandas resample function with logical some Pastas defaults.
+       In Pastas, we assume the timestamp is at the end of the period that
+       belongs to each measurement. For more information on this read the
+       example notebook on preprocessing time series.
+
+    Parameters
+    ----------
+    series : Series
+        time series
+    freq : str
+        frequency string
+    closed: str, default 'right'
+        which side/end of bin interval is closed
+    label: str, default 'right'
+        which bin edge label to label bucket with
+    **kwargs: dict
+
+    Returns
+    -------
+    Resampler
+        pandas Resampler object which can be manipulated using methods such as:
+        '.interpolate()', '.mean()', '.max()' etc. For all options see:
+        https://pandas.pydata.org/docs/reference/resampling.html
+
+    """
+
+    return series.copy().resample(freq, closed=closed, label=label, **kwargs)


### PR DESCRIPTION
# Short Description
A lot of users have difficulty with resampling time series and choosing the right settings when interpolating a time series. This pull request creates a function `pastas.timeseries_utils.resample()` which uses pandas.resample but sets the default arguments for `closed` and `label` to `"right"`. This way users don't have to think that hard about it anymore when resampling and/or interpolating time series. This function can then also be used internally which is nicer I think.

# Checklist before PR can be merged:
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [x] Remove output for all notebooks with changes
