### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           - name: Test suite with py310-ubuntu
             python: "3.10"
             toxenv: py310
+          - name: Test suite with py311-ubuntu
+            python: "3.11"
+            toxenv: py311
           - name: Formatting with black + isort
             python: "3.9"
             toxenv: format

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Get in Touch
 
 Quick installation guide
 ~~~~~~~~~~~~~~~~~~~~~~~~
-To install Pastas, a working version of Python 3.8, 3.9 or 3.10 has to be
+To install Pastas, a working version of Python 3.8, 3.9, 3.10, 3.11 has to be
 installed on your computer. We recommend using the `Anaconda Distribution
 <https://www.continuum.io/downloads>`_ as it includes most of the python
 package dependencies and the Jupyter Notebook software to run the notebooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "matplotlib >= 3.1",
     "pandas >= 1.1",
     "scipy >= 1.8",
-    "numba >= 0.51",
+    "numba >= 0.57.0rc1",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [
@@ -37,6 +37,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering :: Hydrology',
 ]
 
@@ -90,7 +91,7 @@ markers = ["notebooks: run notebooks"]
 legacy_tox_ini = """
     [tox]
     requires = tox>=4
-    env_list = format, lint, notebooks, py{38,39,310}
+    env_list = format, lint, notebooks, py{38,39,310,311}
 
     [testenv]
     description = run unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "matplotlib >= 3.1",
     "pandas >= 1.1",
     "scipy >= 1.8",
-    "numba >= 0.57.0rc1",
+    "numba >= 0.51",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ repository = "https://github.com/pastas/pastas"
 documentation = "https://pastas.readthedocs.io/en/latest/"
 
 [project.optional-dependencies]
-full = ["lmfit >= 1.0.0", "latexify-py"]
+full = [
+    "lmfit >= 1.0.0",
+    "latexify-py@git+https://github.com/google/latexify_py",
+]
 formatting = ["isort", "black[jupyter]"]
 linting = ["flake8"]
 pytesting = ["pytest>=7", "pytest-cov", "pytest-sugar"]


### PR DESCRIPTION
# Short Description
Since Numba supports Python 3.11 (numba >= 0.57) we can add support for Python v3.11 as well.

The optional dependency latexify-py does not support Python 3.11 yet (officially). I now install that from the GitHub page cause that should work but is not very robust. 

# Checklist before PR can be merged:
- [x] closes issue #452 
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] tests added / passed
