### PR TITLE
silence HantushWellModel info msg about r=1.0

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1547,7 +1547,11 @@ class Model:
 
     @get_stressmodel
     def get_response_tmax(
-        self, name: str, p: ArrayLike = None, cutoff: float = 0.999
+        self,
+        name: str,
+        p: ArrayLike = None,
+        cutoff: float = 0.999,
+        warn: bool = True,
     ) -> Union[float, None]:
         """Method to get the tmax used for the response function.
 
@@ -1581,7 +1585,11 @@ class Model:
         else:
             if p is None:
                 p = self.get_parameters(name)
-            tmax = self.stressmodels[name].rfunc.get_tmax(p=p, cutoff=cutoff)
+            if self.stressmodels[name].rfunc._name == "HantushWellModel":
+                kwargs = {"warn": warn}
+            else:
+                kwargs = {}
+            tmax = self.stressmodels[name].rfunc.get_tmax(p=p, cutoff=cutoff, **kwargs)
             return tmax
 
     @get_stressmodel
@@ -1857,8 +1865,12 @@ class Model:
         check["len_oseries_calib"] = len_oseries_calib
 
         for sm_name in self.stressmodels:
+            if self.stressmodels[sm_name].rfunc._name == "HantushWellModel":
+                kwargs = {"warn": False}
+            else:
+                kwargs = {}
             check.loc[sm_name, "response_tmax"] = self.get_response_tmax(
-                sm_name, cutoff=cutoff
+                sm_name, cutoff=cutoff, **kwargs
             )
 
         check["check_ok"] = check["response_tmax"] < check["len_oseries_calib"]

--- a/pastas/modelcompare.py
+++ b/pastas/modelcompare.py
@@ -557,10 +557,10 @@ class CompareModels:
                     if smn not in ml.stressmodels:
                         continue
                     if response == "step":
-                        if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
-                            kwargs = {"warn": False}
-                        else:
-                            kwargs = {}
+                        kwargs = {}
+                        if ml.stressmodels[smn].rfunc is not None:
+                            if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
+                                kwargs = {"warn": False}
                         step = ml.get_step_response(smn, add_0=True, **kwargs)
                         if step is None:
                             continue
@@ -578,10 +578,10 @@ class CompareModels:
                                 color=self.cmap(i),
                             )
                     elif response == "block":
-                        if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
-                            kwargs = {"warn": False}
-                        else:
-                            kwargs = {}
+                        kwargs = {}
+                        if ml.stressmodels[smn].rfunc is not None:
+                            if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
+                                kwargs = {"warn": False}
                         block = ml.get_block_response(smn, **kwargs)
                         if block is None:
                             continue

--- a/pastas/modelcompare.py
+++ b/pastas/modelcompare.py
@@ -557,7 +557,11 @@ class CompareModels:
                     if smn not in ml.stressmodels:
                         continue
                     if response == "step":
-                        step = ml.get_step_response(smn, add_0=True)
+                        if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
+                            kwargs = {"warn": False}
+                        else:
+                            kwargs = {}
+                        step = ml.get_step_response(smn, add_0=True, **kwargs)
                         if step is None:
                             continue
                         if self.axes is None:
@@ -574,7 +578,11 @@ class CompareModels:
                                 color=self.cmap(i),
                             )
                     elif response == "block":
-                        block = ml.get_block_response(smn)
+                        if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
+                            kwargs = {"warn": False}
+                        else:
+                            kwargs = {}
+                        block = ml.get_block_response(smn, **kwargs)
                         if block is None:
                             continue
                         if self.axes is None:

--- a/pastas/modelplots.py
+++ b/pastas/modelplots.py
@@ -265,8 +265,12 @@ class Plotting:
                 i = i + 1
 
             # plot the step response
+            if self.ml.stressmodels[sm_name].rfunc._name == "HantushWellModel":
+                rkwargs = {"warn": False}
+            else:
+                rkwargs = {}
             response = self.ml._get_response(
-                block_or_step=block_or_step, name=sm_name, add_0=True
+                block_or_step=block_or_step, name=sm_name, add_0=True, **rkwargs
             )
 
             if response is not None:

--- a/pastas/modelplots.py
+++ b/pastas/modelplots.py
@@ -265,10 +265,10 @@ class Plotting:
                 i = i + 1
 
             # plot the step response
-            if self.ml.stressmodels[sm_name].rfunc._name == "HantushWellModel":
-                rkwargs = {"warn": False}
-            else:
-                rkwargs = {}
+            rkwargs = {}
+            if self.ml.stressmodels[sm_name].rfunc is not None:
+                if self.ml.stressmodels[sm_name].rfunc._name == "HantushWellModel":
+                    rkwargs = {"warn": False}
             response = self.ml._get_response(
                 block_or_step=block_or_step, name=sm_name, add_0=True, **rkwargs
             )


### PR DESCRIPTION
This PR silences the info message internally by adding a warn keyword argument and checking whether the current rfunc is HantushWellModel in `ps.Model` methods.

In my opinion this is a bit ugly, but perhaps worth silencing the confusing message? So far 3 issues have been posted about it, so it is confusing people.

# Checklist before PR can be merged:
- [x] closes issue #602
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [x] Remove output for all notebooks with changes
