### PR TITLE
remove NumPy < v1.24 requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 ]
 requires-python = ">= 3.8"
 dependencies = [
-    "numpy >= 1.17, < 1.24",
+    "numpy >= 1.17",
     "matplotlib >= 3.1",
     "pandas >= 1.1",
     "scipy >= 1.8",


### PR DESCRIPTION
no longer needed since Numba v0.57