### PR TITLE
Check if precipitation is probably in mm/d

### DIFF
--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -1020,9 +1020,12 @@ class RechargeModel(StressModelBase):
     ----------
     prec: pandas.Series
         pandas.Series with pandas.DatetimeIndex containing the precipitation series.
+        The precipitation series should be provided in mm/day when a nonlinear model is
+        used.
     evap: pandas.Series
         pandas.Series with pandas.DatetimeIndex containing the potential evaporation
-        series.
+        series. The evaporation series should be provided in mm/day when a nonlinear
+        model is used.
     rfunc: pastas.rfunc instance, optional
         Instance of the response function used in the convolution with the stress.
         Default is ps.Exponential().
@@ -1033,7 +1036,8 @@ class RechargeModel(StressModelBase):
         These can be accessed through ps.rch. Default is ps.rch.Linear().
     temp: pandas.Series, optional
         pandas.Series with pandas.DatetimeIndex containing the temperature series.
-        It depends on the recharge model is this argument is required or not.
+        It depends on the recharge model is this argument is required or not. The
+        temperature series should be provided in degrees Celsius.
     settings: list of dicts or str, optional
         The settings of the precipitation and evaporation time series, in this order.
         This can be a string referring to a predefined settings dict (defined in
@@ -1055,7 +1059,8 @@ class RechargeModel(StressModelBase):
     evaporation in two steps. In the first step a recharge flux is computed by a
     model determined by the input argument `recharge`. In the second step this
     recharge flux is convoluted with a response function to obtain the contribution
-    of recharge to the groundwater levels.
+    of recharge to the groundwater levels. If a nonlinear recharge model is used, the
+    precipitation should be in mm/d.
 
     Examples
     --------
@@ -1067,6 +1072,14 @@ class RechargeModel(StressModelBase):
     --------
     We recommend not to store a RechargeModel is a variable named `rm`. This name is
     already reserved in IPython to remove files and will cause problems later.
+
+    Raises
+    ------
+    A warning if the maximum value of the precipitation series is smaller than 12 and a
+    nonlinear recharge model is applied. This is likely an indication that the units of
+    the precipitation series are in m/d instead of mm/d. Please check the units of the
+    precipitation series.
+
     """
 
     _name = "RechargeModel"
@@ -1150,6 +1163,18 @@ class RechargeModel(StressModelBase):
             self.nsplit = 2
         else:
             self.nsplit = 1
+
+            # Check if precipitation is likely in mm/d and not m/d. If the maximum
+            # value of the annual sums is smaller than 12 (m/d), the highest annual
+            # precipitation in the world, then the precipitation is very likely in m/d
+            # and not in mm/d. In this case a warning is given for nonlinear models.
+
+            if prec.resample("A").sum().max() < 12:
+                msg = (
+                    "The maximum value of the precipitation series is smaller than 12. "
+                    "Please double-check if the stresses are in mm/d and not in m/d."
+                )
+                logger.warning(msg)
 
     def set_init_parameters(self) -> None:
         """Internal method to set the initial parameters."""


### PR DESCRIPTION
# Short Description
Simple but I think powerful check to see if precipitation may be provided in m/d instead of mm/d for the nonlinear recharge models, which is a common mistake causing issues. Also improved docs on this.

# Checklist before PR can be merged:
- [ ] closes issue #609 
- [ ] is documented
- [ ] Format code with [Black formatting](https://black.readthedocs.io)
- [ ] type hints for functions and methods
- [ ] tests added / passed
- [ ] Example Notebook (for new features)
- [ ] Remove output for all notebooks with changes
