### PR TITLE
Implement freq_obs for sampling observations prior to optimization

### DIFF
--- a/doc/examples/example_freq_obs.py
+++ b/doc/examples/example_freq_obs.py
@@ -1,0 +1,32 @@
+"""
+This test file is meant for developing purposes. Providing an easy method to
+test the functioning of Pastas during development.
+
+"""
+import pandas as pd
+
+import pastas as ps
+
+ps.set_log_level("INFO")
+
+# read observations and create the time series model
+obs = pd.read_csv("data/head_nb1.csv", index_col=0, parse_dates=True).squeeze("columns")
+
+# Create the time series model
+ml = ps.Model(obs, name="head")
+
+# read weather data
+rain = pd.read_csv("data/rain_nb1.csv", index_col=0, parse_dates=True).squeeze(
+    "columns"
+)
+evap = pd.read_csv("data/evap_nb1.csv", index_col=0, parse_dates=True).squeeze(
+    "columns"
+)
+
+# Create stress
+sm = ps.RechargeModel(prec=rain, evap=evap, rfunc=ps.Exponential(), name="recharge")
+ml.add_stressmodel(sm)
+
+# Solve and only fit on one observation per year
+ml.solve(freq_obs="365D")
+ml.plot()

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -131,6 +131,7 @@ class Model:
             "noise": noisemodel,
             "solver": None,
             "fit_constant": True,
+            "freq_obs": None,
         }
 
         if constant:
@@ -599,6 +600,7 @@ class Model:
         tmin: Optional[TimestampType] = None,
         tmax: Optional[TimestampType] = None,
         freq: Optional[str] = None,
+        freq_obs: Optional[str] = None,
         update_observations: bool = False,
     ) -> Series:
         """Method that returns the observations series used for calibration.
@@ -639,7 +641,10 @@ class Model:
             tmax = self.get_tmax(tmax, use_oseries=False, use_stresses=True)
         if freq is None:
             freq = self.settings["freq"]
-
+        if freq_obs is None:
+            freq_obs = self.settings["freq_obs"]
+        if freq_obs is not None:
+            freq = freq_obs
         for key, setting in zip([tmin, tmax, freq], ["tmin", "tmax", "freq"]):
             if key != self.settings[setting]:
                 update_observations = True
@@ -668,6 +673,7 @@ class Model:
         weights: Optional[Series] = None,
         initial: bool = True,
         fit_constant: bool = True,
+        freq_obs: Optional[str] = None,
     ) -> None:
         """Method to initialize the model.
 
@@ -686,6 +692,7 @@ class Model:
         self.settings["noise"] = noise
         self.settings["weights"] = weights
         self.settings["fit_constant"] = fit_constant
+        self.settings["freq_obs"] = freq_obs
 
         # Set the frequency & warmup
         if freq:
@@ -713,6 +720,7 @@ class Model:
             tmin=self.settings["tmin"],
             tmax=self.settings["tmax"],
             freq=self.settings["freq"],
+            freq_obs=self.settings["freq_obs"],
             update_observations=True,
         )
         self.interpolate_simulation = None
@@ -741,6 +749,7 @@ class Model:
         initial: bool = True,
         weights: Optional[Series] = None,
         fit_constant: bool = True,
+        freq_obs: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Method to solve the time series model.
@@ -798,7 +807,9 @@ class Model:
         """
 
         # Initialize the model
-        self.initialize(tmin, tmax, freq, warmup, noise, weights, initial, fit_constant)
+        self.initialize(
+            tmin, tmax, freq, warmup, noise, weights, initial, fit_constant, freq_obs
+        )
 
         if self.oseries_calib.empty:
             raise ValueError(

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -39,6 +39,7 @@ class NoiseModelBase:
     def __init__(self) -> None:
         self.nparam = 1
         self.name = "noise"
+        self.norm = None
         self.parameters = DataFrame(
             columns=["initial", "pmin", "pmax", "vary", "name", "dist"]
         )

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -39,7 +39,6 @@ class NoiseModelBase:
     def __init__(self) -> None:
         self.nparam = 1
         self.name = "noise"
-        self.norm = None
         self.parameters = DataFrame(
             columns=["initial", "pmin", "pmax", "vary", "name", "dist"]
         )


### PR DESCRIPTION
# Short Description
This allows users to select a different time step for the observation data in `ml.solve()`. The model time step remains unchanged but the optimization is performed on a sample of the original oseries. E.g., model timestep is daily, but the model is fit on head observations once every 14 days:

```python
ml.solve(freq_obs="14D")
```

# Checklist before PR can be merged:
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example (for new features)
- [x] Remove output for all notebooks with changes
