### PR TITLE
Improve `ml.plots.stack_results()`

### DIFF
--- a/doc/examples/multiple_wells.ipynb
+++ b/doc/examples/multiple_wells.ipynb
@@ -387,7 +387,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ml_wm.plots.stacked_results(figsize=(10, 8), stacklegend=True);"
+    "ml_wm.plots.stacked_results(\n",
+    "    figsize=(10, 8),\n",
+    "    stacklegend=True,\n",
+    "    stackcolors={\"Extraction_2\": \"C1\", \"Extraction_3\": \"C2\"},\n",
+    ");"
    ]
   },
   {
@@ -494,7 +498,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visually compare the two models, including the calculated contribution of the wells:"
+    "Visually compare the two models, including the calculated contribution of the wells.\n",
+    "\n",
+    "Note that there is some extra code at the bottom to calculate two step responses for the\n",
+    "\"WellModel\" model, for comparison purposes with the \"2-wells\" model."
    ]
   },
   {
@@ -520,7 +527,20 @@
     "mc.axes[\"con1\"].plot(\n",
     "    sumwells.index, sumwells, ls=\"dashed\", color=\"C0\", label=\"sum 2_wells\"\n",
     ")\n",
-    "mc.axes[\"con1\"].legend(loc=(0, 1), frameon=False, ncol=4);"
+    "mc.axes[\"con1\"].legend(loc=(0, 1), frameon=False, ncol=4)\n",
+    "\n",
+    "# remove WellModel response for r=1m and add response twice, scaled with actual\n",
+    "# distances, for comparison with the two responses from the first model\n",
+    "mc.axes[\"rf1\"].lines[-1].remove()  # remove original step response\n",
+    "for istress in range(2):\n",
+    "    # get parameters and distance for istress\n",
+    "    p = ml_wm.stressmodels[\"WellModel\"].get_parameters(istress=istress)\n",
+    "    # calculate step\n",
+    "    step = ml_wm.get_step_response(\"WellModel\", p=p)\n",
+    "    # plot step\n",
+    "    mc.axes[\"rf1\"].plot(step.index, step, color=\"C1\")\n",
+    "# recalculate axes limits\n",
+    "mc.axes[\"rf1\"].relim()"
    ]
   },
   {
@@ -532,8 +552,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "artesia",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Short Description
The plot produced with `ml.plots.stacked_results()` now shows multiple step responses for each well in `WellModel`, each scaled with distance between pumping well and observation well. The colors are matched to those in the stacked results plot. 

Add improved support for passing a dictionary of colors to `stackcolors` kwarg. This can be useful for always using the same color for a particular well in these plots. 

An example is shown in the notebook [doc/examples/multiple_wells.ipynb](https://github.com/pastas/pastas/pull/656/files#diff-0dd3bbb343179f4ba803dc1eb0b64295a0344a6d576d1221d4f4c68c2d1ceaab)

# Checklist before PR can be merged:
- [x] closes issue #617 
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [x] Remove output for all notebooks with changes
