### PR TITLE
Add plugins support to pastas

### DIFF
--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -8,6 +8,7 @@ import pastas.plots as plots
 import pastas.recharge as rch
 import pastas.stats as stats
 import pastas.timeseries_utils as ts
+from pastas import plugins
 
 from .decorators import set_use_numba
 from .model import Model

--- a/pastas/plugins/__init__.py
+++ b/pastas/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .plugins import register

--- a/pastas/plugins/plugins.py
+++ b/pastas/plugins/plugins.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PluginRegistrationError(Exception):
+    pass
+
+
+def register(module, target: Optional[str] = "plugins"):
+    """Register a plugin module in pastas.
+
+    Parameters
+    ----------
+    module : module
+        Python file containing plugin classes or functions.
+    target : Optional[str], optional
+        target sub-module for registering plugin, by default "plugins". See usage
+        section for more details.
+
+    Usage
+    -----
+    Register a new type of stressmodel in pastas::
+
+        import pastas as ps
+
+        # a file my_new_stressmodel.py containing a class NewStressModel
+        import my_new_stressmodel
+
+        # register NewStressModel in pastas.stressmodels: ps.stressmodels.NewStressModel
+        ps.plugins.register(my_new_stressmodel, target="stressmodels")
+
+        # register NewStressModel in pastas root: ps.NewStressModel
+        ps.plugins.register(my_new_stressmodel, target=None)
+
+        # register NewStressModel in new sub-module: ps.experimental.NewStressModel
+        ps.plugins.register(my_new_stressmodel, target="experimental")
+
+    """
+    import pastas as ps
+
+    objs = [o for o in dir(module) if not o.startswith("_")]
+    if target is not None:
+        try:
+            target = getattr(ps, target)
+        except AttributeError:
+            setattr(ps, target, module)
+            target = getattr(ps, target)
+    else:
+        target = ps
+    for obj in objs:
+        if obj in dir(target):
+            raise PluginRegistrationError(
+                f"Failed registering plugin, <{target.__name__}> already "
+                f"contains class or method named '{obj}'."
+            )
+        setattr(target, obj, getattr(module, obj))
+        logger.info(f"Registered plugin '{obj}' in <{target.__name__}>.")

--- a/tests/fake_plugin.py
+++ b/tests/fake_plugin.py
@@ -5,13 +5,3 @@ class FakeStressModel:
     def __init__(self):
         """I am a Fake StressModel, do not use me!"""
         pass
-
-
-# class StressModel:
-#     """I am a badly named plugin class as I conflict with a pastas default."""
-
-#     def __init__(self):
-#         """I am a badly named StressModel, do not use me!"""
-#         pass
-
-# %%

--- a/tests/fake_plugin.py
+++ b/tests/fake_plugin.py
@@ -1,0 +1,17 @@
+# %%
+class FakeStressModel:
+    """I am a plugin class."""
+
+    def __init__(self):
+        """I am a Fake StressModel, do not use me!"""
+        pass
+
+
+# class StressModel:
+#     """I am a badly named plugin class as I conflict with a pastas default."""
+
+#     def __init__(self):
+#         """I am a badly named StressModel, do not use me!"""
+#         pass
+
+# %%

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,36 @@
+import pytest
+
+import pastas as ps
+from pastas.plugins.plugins import PluginRegistrationError
+
+from . import fake_plugin as my_plugin
+
+
+def test_register_plugin_in_root():
+    # register in root
+    ps.plugins.register(my_plugin, target=None)
+    assert hasattr(ps, "FakeStressModel")
+
+
+def test_register_plugin_in_existing_submodule():
+    # register in existing ps.stressmodels
+    ps.plugins.register(my_plugin, target="stressmodels")
+    assert hasattr(ps.stressmodels, "FakeStressModel")
+
+
+def test_register_plugin_in_nonexisting_submodule():
+    # register in non-existing sub module
+    ps.plugins.register(my_plugin, target="plugins")
+    assert hasattr(ps.plugins, "FakeStressModel")
+
+
+def test_register_plugin_with_existing_name():
+    # plugin already registered in second test
+    # registering again should raise error
+    with pytest.raises(PluginRegistrationError) as excinfo:
+        ps.plugins.register(my_plugin, target="plugins")
+
+    assert str(excinfo.value) == (
+        "Failed registering plugin, <pastas.plugins> already "
+        "contains class or method named 'FakeStressModel'."
+    )


### PR DESCRIPTION
# Introducing Plugins
Plugins are custom code (classes and functions) that can be registered in pastas. This allows custom Pastas-related to code to be developed in separate repositories, but they can be made available within pastas. 

Some examples of custom code could be:
* New stressmodels that support convolution. These could be registered under `pastas.stressmodels`
* New stressmodels that do not use convolution. These could be registered under a new submodule, i.e. `pastas.reservoirs`
* Completely new module for specific types of plots or post-processing. These could be registered under `ps.customplots`, or `ps.postprocessing`, respectively
* etc.

## How does it work? 
Let's say you've developed some new StressModels in a file called `my_new_stressmodels.py`. All you have to do is import your module, and then use `ps.plugins.register()` to register the plugin classes and methods in pastas. The `target` keyword argument allows you to specify the location within the pastas module where you want your custom code to be made available.

```python
import pastas as ps
import my_new_stressmodels as my_plugin

# to register new classes under `pastas.stressmodels`
ps.plugins.register(my_plugin, target="stressmodels")

# to register in a completely new sub-module
ps.plugins.register(my_plugin, target="reservoirs")

# to register all classes and functions in pastas root
ps.plugins.register(my_plugin, target=None)
```

# Checklist before PR can be merged:
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [ ] tests added / passed
- [ ] Example Notebook (for new features)
