### PR TITLE
add 'norm' attribute to NoiseModelBase

### DIFF
--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -39,6 +39,7 @@ class NoiseModelBase:
     def __init__(self) -> None:
         self.nparam = 1
         self.name = "noise"
+        self.norm = None
         self.parameters = DataFrame(
             columns=["initial", "pmin", "pmax", "vary", "name", "dist"]
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -63,6 +63,7 @@ def test_armamodel() -> None:
     ml = ps.Model(obs, name="Test_Model", noisemodel=False)
     ml.add_noisemodel(ps.ArmaModel())
     ml.solve()
+    ml.to_file("test.pas")
 
 
 def test_del_noisemodel(ml_empty: ps.Model) -> None:


### PR DESCRIPTION
# Short Description

Fix for issue 648, where a Pastas model with the ARMA noise model could not be saved due to a missing 'norm' attribute in the noise model. Fixed this in the noisemodelbase so this attribute is always present and does not cause issues in future work.

# Checklist before PR can be merged:
- [x] closes issue #648 
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] tests added / passed
