### PR TITLE
better error message when a class instead of an instance is provided for the rfunc

### DIFF
--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -18,6 +18,7 @@ from logging import getLogger
 
 # Type Hinting
 from typing import List, Optional, Tuple, Union
+from inspect import isclass
 
 import numpy as np
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat, date_range
@@ -80,6 +81,11 @@ class StressModelBase:
         self.freq = None
 
         if rfunc is not None:
+            if isclass(rfunc):
+                raise TypeError(
+                    "the rfunc argument must be an instance of response function, not "
+                    "a class. Please provide an instance, e.g., ps.Exponential()"
+                )
             rfunc.update_rfunc_settings(up=up, gain_scale_factor=gain_scale_factor)
         self.rfunc = rfunc
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -14,11 +14,11 @@ See Also
 pastas.model.Model.add_stressmodel
 """
 
+from inspect import isclass
 from logging import getLogger
 
 # Type Hinting
 from typing import List, Optional, Tuple, Union
-from inspect import isclass
 
 import numpy as np
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat, date_range


### PR DESCRIPTION
# Short Description

Provide better error message when a class instead of an instance is provided for the rfunc.

# Checklist before PR can be merged:
- [x] closes issue #627 
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
