### PR TITLE
fix for Problem adding LinearTrend #675

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -44,7 +44,6 @@ from pastas.typing import Solver, StressModel, TimestampType
 from pastas.utils import validate_name
 from pastas.version import __version__
 
-
 logger = getLogger(__name__)
 
 

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1907,7 +1907,9 @@ class Model:
         len_oseries_calib = (self.settings["tmax"] - self.settings["tmin"]).days
 
         # only check stressmodels with a response function
-        sm_names = [key for key, item in self.stressmodels.items() if item.rfunc is not None]
+        sm_names = [
+            key for key, item in self.stressmodels.items() if item.rfunc is not None
+        ]
 
         check = DataFrame(
             index=sm_names,

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -27,6 +27,7 @@ from pastas.io.base import _load_model, dump
 from pastas.modelstats import Statistics
 from pastas.noisemodels import NoiseModel
 from pastas.plotting.modelplots import Plotting, _table_formatter_stderr
+from pastas.rfunc import HantushWellModel
 from pastas.solver import LeastSquares
 from pastas.stressmodels import Constant
 from pastas.timeseries import TimeSeries
@@ -1632,7 +1633,7 @@ class Model:
         else:
             if p is None:
                 p = self.get_parameters(name)
-            if self.stressmodels[name].rfunc._name == "HantushWellModel":
+            if isinstance(self.stressmodels[name].rfunc, HantushWellModel):
                 kwargs = {"warn": warn}
             else:
                 kwargs = {}
@@ -1916,8 +1917,8 @@ class Model:
         )
         check["len_oseries_calib"] = len_oseries_calib
 
-        for sm_name in sm_names:
-            if self.stressmodels[sm_name].rfunc._name == "HantushWellModel":
+        for sm_name in self.stressmodels:
+            if isinstance(self.stressmodels[sm_name].rfunc, HantushWellModel):
                 kwargs = {"warn": False}
             else:
                 kwargs = {}

--- a/pastas/plotting/modelcompare.py
+++ b/pastas/plotting/modelcompare.py
@@ -10,6 +10,7 @@ import numpy as np
 from pandas import DataFrame, concat
 
 from pastas.plotting.plotutil import _table_formatter_params, share_xaxes, share_yaxes
+from pastas.rfunc import HantushWellModel
 from pastas.stats.core import acf
 from pastas.typing import Axes, Model
 
@@ -574,7 +575,7 @@ class CompareModels:
                     if response == "step":
                         kwargs = {}
                         if ml.stressmodels[smn].rfunc is not None:
-                            if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
+                            if isinstance(ml.stressmodels[smn].rfunc, HantushWellModel):
                                 kwargs = {"warn": False}
                         step = ml.get_step_response(smn, add_0=True, **kwargs)
                         if step is None:
@@ -595,7 +596,7 @@ class CompareModels:
                     elif response == "block":
                         kwargs = {}
                         if ml.stressmodels[smn].rfunc is not None:
-                            if ml.stressmodels[smn].rfunc._name == "HantushWellModel":
+                            if isinstance(ml.stressmodels[smn].rfunc, HantushWellModel):
                                 kwargs = {"warn": False}
                         block = ml.get_block_response(smn, **kwargs)
                         if block is None:

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -19,6 +19,7 @@ from pastas.plotting.plotutil import (
     _table_formatter_params,
     _table_formatter_stderr,
 )
+from pastas.rfunc import HantushWellModel
 from pastas.typing import Axes, Figure, Model, TimestampType
 
 logger = logging.getLogger(__name__)
@@ -267,7 +268,7 @@ class Plotting:
             # plot the step response
             rkwargs = {}
             if self.ml.stressmodels[sm_name].rfunc is not None:
-                if self.ml.stressmodels[sm_name].rfunc._name == "HantushWellModel":
+                if isinstance(self.ml.stressmodels[sm_name].rfunc, HantushWellModel):
                     rkwargs = {"warn": False}
             response = self.ml._get_response(
                 block_or_step=block_or_step, name=sm_name, add_0=True, **rkwargs


### PR DESCRIPTION
Close issue 675 and change the behavior of `_check_response_tmax` in such a way that this check is only done for stressmodels with a response function. Stressmodels without a response function, such as 'LinearTrend', will not be checked.
