### PR TITLE
Support Python 3.12 + GitHub workflow update versions

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -12,4 +12,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.6.2
+      - uses: toshimaru/auto-author-assign@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           - name: Test suite with py312-ubuntu
             python: "3.12"
             toxenv: py312
-            experimental: true
+            experimental: false
           - name: Formatting with black + isort
             python: "3.9"
             toxenv: format
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           check-latest: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/test_benchmark_notebooks.yml
+++ b/.github/workflows/test_benchmark_notebooks.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           check-latest: true


### PR DESCRIPTION
# Short Description
Numba released [version 0.59.0](https://github.com/numba/numba/releases/tag/0.59.0) so we can support python 3.12 fully now as well. 
