### PR TITLE
Add load_dataset method to pastas

### DIFF
--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -40,6 +40,7 @@ from pastas.stressmodels import (
 )
 from pastas.timeseries import validate_oseries, validate_stress
 from pastas.transform import ThresholdTransform
+from pastas.dataset import load_dataset
 from pastas.utils import initialize_logger, set_log_level
 from pastas.version import __version__, show_versions
 

--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -9,7 +9,7 @@ import pastas.recharge as rch
 import pastas.stats as stats
 import pastas.timeseries_utils as ts
 from pastas import extensions
-from pastas.dataset import load_dataset
+from pastas.dataset import load_dataset, list_datasets
 from pastas.decorators import set_use_numba
 from pastas.model import Model
 from pastas.noisemodels import ArmaModel, NoiseModel

--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -9,6 +9,7 @@ import pastas.recharge as rch
 import pastas.stats as stats
 import pastas.timeseries_utils as ts
 from pastas import extensions
+from pastas.dataset import load_dataset
 from pastas.decorators import set_use_numba
 from pastas.model import Model
 from pastas.noisemodels import ArmaModel, NoiseModel
@@ -40,7 +41,6 @@ from pastas.stressmodels import (
 )
 from pastas.timeseries import validate_oseries, validate_stress
 from pastas.transform import ThresholdTransform
-from pastas.dataset import load_dataset
 from pastas.utils import initialize_logger, set_log_level
 from pastas.version import __version__, show_versions
 

--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -9,7 +9,7 @@ import pastas.recharge as rch
 import pastas.stats as stats
 import pastas.timeseries_utils as ts
 from pastas import extensions
-from pastas.dataset import load_dataset, list_datasets
+from pastas.dataset import list_datasets, load_dataset
 from pastas.decorators import set_use_numba
 from pastas.model import Model
 from pastas.noisemodels import ArmaModel, NoiseModel

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -30,15 +30,17 @@ def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
 
     Raises
     ------
-    Exception: If the request status code is not 200.
+    Exception: If the request status code is not 200 (OK), an exception is raised. This
+    is likely due to an invalid folder name. Check the pastas-data repository on GitHub
+    for available datasets.
 
     Examples
     --------
     >>> ps.load_dataset("collenteur_2021")
-    Returns the dataset from the "collenteur_2023" subfolder as a pandas DataFrame.
+    Returns the dataset from the "collenteur_2021" subfolder as a pandas DataFrame.
 
     >>> ps.load_dataset("collenteur_2023")
-    Returns a dictionary with datasets from the "collenteur_2021" subfolder. The keys
+    Returns a dictionary with datasets from the "collenteur_2023" subfolder. The keys
     are the file names and the values are pandas DataFrames.
 
     """
@@ -52,7 +54,7 @@ def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
         )
 
     # Get the folder from the pastas-data repository
-    r = requests.api.get(f"{GITHUB_URL}/{name}/")
+    r = requests.get(f"{GITHUB_URL}/{name}/")
 
     # Check if requests status is okay, otherwise raise error and return status code
     if not r.status_code == 200:
@@ -74,3 +76,8 @@ def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
         return list(data.values())[0]
     elif len(data) > 1:
         return data
+    else:
+        raise Exception(
+            f"No csv files found in the folder {name}. Check the pastas-data repository "
+            "on GitHub for available datasets."
+        )

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -82,3 +82,50 @@ def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
             f"No csv files found in the folder {name}. Check the pastas-data repository "
             "on GitHub for available datasets."
         )
+
+
+def list_datasets() -> list[str]:
+    """Print a list of available datasets in the pastas-data repository on GitHub.
+
+    Returns
+    -------
+    list[str]
+        A list of available datasets in the pastas-data repository on GitHub.
+        Prints a list of available datasets in the pastas-data repository on GitHub.
+
+    Examples
+    --------
+    >>> ps.list_datasets()
+    Prints a list of available datasets in the pastas-data repository on GitHub.
+
+    """
+    # Try to import requests, if not installed raise error
+    try:
+        import requests
+    except ImportError:
+        raise ImportError(
+            "The requests package is required to load datasets from the pastas-data "
+            "repository. Install requests using 'pip install requests'."
+        )
+
+    # Get the folder from the pastas-data repository
+    r = requests.get(GITHUB_URL)
+
+    # Check if requests status is okay, otherwise raise error and return status code
+    if not r.status_code == 200:
+        raise Exception(f"Error: {r.status_code}. Reason: {r.reason}. ")
+
+    # Get information about the files in the folder
+    data = []
+
+    # Loop over the files in the folder
+    for file in r.json():
+        if file["type"] == "dir":
+            data.append(file["name"])
+
+    # Print the list of datasets
+    print("Available datasets in the pastas-data repository on GitHub:")
+    for folder in data:
+        print(f" - {folder}")
+    print(f"Use ps.load_dataset('folder_name') to load a dataset from the repository.")
+    return data

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -5,7 +5,7 @@ a subfolder in the pastas-data repository.
 
 """
 
-from typing import Dict, Union, List
+from typing import Dict, List, Union
 
 from pandas import DataFrame, read_csv
 

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -32,6 +32,15 @@ def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
     ------
     Exception: If the request status code is not 200.
 
+    Examples
+    --------
+    >>> ps.load_dataset("collenteur_2021")
+    Returns the dataset from the "collenteur_2023" subfolder as a pandas DataFrame.
+
+    >>> ps.load_dataset("collenteur_2023")
+    Returns a dictionary with datasets from the "collenteur_2021" subfolder. The keys
+    are the file names and the values are pandas DataFrames.
+
     """
     # Try to import requests, if not installed raise error
     try:

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -5,7 +5,7 @@ a subfolder in the pastas-data repository.
 
 """
 
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 from pandas import DataFrame, read_csv
 
@@ -84,7 +84,7 @@ def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
         )
 
 
-def list_datasets() -> list[str]:
+def list_datasets() -> List[str]:
     """Print a list of available datasets in the pastas-data repository on GitHub.
 
     Returns

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -1,0 +1,67 @@
+"""This module contains functions to load datasets from the pastas-data repository on
+GitHub. The datasets are used for testing and examples in the documentation. The
+load_dataset function can be used to load a single csv file or multiple csv files from
+a subfolder in the pastas-data repository.
+
+"""
+
+from pandas import read_csv, DataFrame
+from typing import Union, Dict
+
+GITHUB_URL = "https://api.github.com/repos/pastas/pastas-data/contents/"
+
+
+def load_dataset(name: str) -> Union[DataFrame, Dict[str, DataFrame]]:
+    """Load csv-files from a subfolder in the pastas dataset repository on GitHub.
+
+    Parameters
+    ----------
+    name : str
+        The name of the subfolder, i.e., collenteur_2023. For a list of available
+        datasets, see the pastas-data repository on GitHub
+        (www.github.com/pastas/pastas-data).
+
+    Returns
+    -------
+    Union[pd.DataFrame, Dict[str, pd.DataFrame]]
+        The loaded dataset(s). If one csv file is found, returns a pandas DataFrame.
+        If multiple csv files are found, returns a dictionary with file names as keys
+        and dataframes as values.
+
+    Raises
+    ------
+    Exception: If the request status code is not 200.
+
+    """
+    # Try to import requests, if not installed raise error
+    try:
+        import requests
+    except ImportError:
+        raise ImportError(
+            "The requests package is required to load datasets from the pastas-data "
+            "repository. Install requests using 'pip install requests'."
+        )
+
+    # Get the folder from the pastas-data repository
+    r = requests.api.get(f"{GITHUB_URL}/{name}/")
+
+    # Check if requests status is okay, otherwise raise error and return status code
+    if not r.status_code == 200:
+        raise Exception(f"Error: {r.status_code}. Reason: {r.reason}. ")
+
+    # Get information about the files in the folder
+    data = {}
+
+    # Loop over the files in the folder
+    for file in r.json():
+        if file["name"].endswith(".csv"):
+            # Read file
+            df = read_csv(file["download_url"], index_col=0, parse_dates=True)
+            data[file["name"].split(".")[0]] = df
+
+    # Return the data, if only one file is found return the dataframe, otherwise return
+    # a dictionary with the dataframes
+    if len(data) == 1:
+        return list(data.values())[0]
+    elif len(data) > 1:
+        return data

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -5,8 +5,9 @@ a subfolder in the pastas-data repository.
 
 """
 
-from pandas import read_csv, DataFrame
-from typing import Union, Dict
+from typing import Dict, Union
+
+from pandas import DataFrame, read_csv
 
 GITHUB_URL = "https://api.github.com/repos/pastas/pastas-data/contents/"
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,24 @@
+import pytest
+from pastas.dataset import load_dataset
+from pandas import DataFrame
+
+
+def test_load_single_csv():
+    # Test loading a single csv file
+    dataset = load_dataset("collenteur_2021")
+    assert isinstance(dataset, DataFrame)
+
+
+def test_load_multiple_csv():
+    # Test loading multiple csv files
+    dataset = load_dataset("collenteur_2023")
+    assert isinstance(dataset, dict)
+    assert len(dataset) > 1
+    for key, value in dataset.items():
+        assert isinstance(value, DataFrame)
+
+
+def test_invalid_folder_name():
+    # Test loading dataset with invalid folder name
+    with pytest.raises(Exception):
+        load_dataset("invalid_folder_name")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,5 @@
 import pytest
-from pastas.dataset import load_dataset
+from pastas.dataset import load_dataset, list_datasets
 from pandas import DataFrame
 
 
@@ -22,3 +22,11 @@ def test_invalid_folder_name():
     # Test loading dataset with invalid folder name
     with pytest.raises(Exception):
         load_dataset("invalid_folder_name")
+
+
+def test_list_datasets():
+    # Test listing available datasets
+    list_datasets()
+    # Add assertions here to verify the output of the function
+    # For example, you can check if the output contains certain dataset names
+    # assert "collenteur_2021" in list_datasets()


### PR DESCRIPTION
# Short Description

This PR adds a load_dataset method to pastas, allowing users to load predefined test datasets from the Pastas new dataset repo (https://github.com/pastas/pastas-data/tree/main). For now, only a limited number of datasets are available, but more can be added later. 

# Checklist before PR can be merged:
- [x] closes issue #673 
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed

# Usage

Simple, just type:

`ps.load_dataset("collenteur_2021")`
