### PR TITLE
Fix issue 702

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -480,12 +480,16 @@ class Model:
             tmax = self.settings["tmax"]
         if freq is None:
             freq = self.settings["freq"]
+        if self.settings["freq_obs"] is None:
+            freq_obs = freq
+        else:
+            freq_obs = self.settings["freq_obs"]
 
         # simulate model
         sim = self.simulate(p, tmin, tmax, freq, warmup, return_warmup=False)
 
         # Get the oseries calibration series
-        oseries_calib = self.observations(tmin, tmax, freq)
+        oseries_calib = self.observations(tmin, tmax, freq_obs)
 
         # Get simulation at the correct indices
         if self.interpolate_simulation is None:

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -170,13 +170,7 @@ class RfuncBase:
         """
         return
 
-    def block(
-        self,
-        p: ArrayLike,
-        dt: float = 1.0,
-        cutoff: Optional[float] = None,
-        maxtmax: Optional[int] = None,
-    ) -> ArrayLike:
+    def block(self, p: ArrayLike, dt: float = 1.0, **kwargs) -> ArrayLike:
         """Method to return the block function.
 
         Parameters
@@ -186,17 +180,15 @@ class RfuncBase:
             parameters.
         dt: float
             timestep as a multiple of one day.
-        cutoff: float, optional
-            proportion after which the step function is cut off.
-        maxtmax: int, optional
-            Maximum timestep to compute the block response for.
+        kwargs: dict
+            kwargs are passed onto self.step()
 
         Returns
         -------
         s: array_like
             Array with the block response.
         """
-        s = self.step(p=p, dt=dt, cutoff=cutoff, maxtmax=maxtmax)
+        s = self.step(p=p, dt=dt, **kwargs)
         return np.append(s[0], np.subtract(s[1:], s[:-1]))
 
     @staticmethod


### PR DESCRIPTION
# Short Description
Fix issue #702

This PR also fixes a bug where the use of `freq_obs` would result in the following error, when saving and reading a model from file again:
`ValueError: Weights and observations time series have different lengths! Check observation and simulation time series.`

# Checklist before PR can be merged:
- [x] closes issue #702
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [ ] Remove output for all notebooks with changes
