### PR TITLE
Fix warning Day.delta is deprecated

### DIFF
--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -52,15 +52,16 @@ def _frequency_is_supported(freq: str) -> str:
 
     """
     offset = to_offset(freq)
-    if not hasattr(offset, "delta"):
+    try:
+        Timedelta(offset)
+    except:
         msg = "Frequency {} not supported.".format(freq)
         logger.error(msg)
         raise ValueError(msg)
+    if offset.n == 1:
+        freq = offset.name
     else:
-        if offset.n == 1:
-            freq = offset.name
-        else:
-            freq = str(offset.n) + offset.name
+        freq = str(offset.n) + offset.name
     return freq
 
 
@@ -87,9 +88,9 @@ def _get_stress_dt(freq: str) -> float:
         return None
     # Get the frequency string and multiplier
     offset = to_offset(freq)
-    if hasattr(offset, "delta"):
+    try:
         dt = Timedelta(offset) / Timedelta(1, "D")
-    else:
+    except:
         num = offset.n
         freq = offset._prefix
         if freq in ["A", "Y", "AS", "YS", "BA", "BY", "BAS", "BYS"]:

--- a/tests/test_timeseries_utils.py
+++ b/tests/test_timeseries_utils.py
@@ -1,0 +1,16 @@
+import pastas as ps
+import pytest
+
+
+def test_frequency_is_supported():
+    ps.ts._frequency_is_supported("D")
+    ps.ts._frequency_is_supported("7D")
+    with pytest.raises(Exception):
+        ps.ts._frequency_is_supported("SMS")
+
+
+def test_get_stress_dt():
+    assert ps.ts._get_stress_dt("D") == 1.0
+    assert ps.ts._get_stress_dt("7D") == 7.0
+    assert ps.ts._get_stress_dt("W") == 7.0
+    assert ps.ts._get_stress_dt("SMS") == 15.0


### PR DESCRIPTION
This PR fixes the following warning you get in Pandas version 2.2.1 when loading a model from file or pastastore:
`FutureWarning: Day.delta is deprecated and will be removed in a future version. Use pd.Timedelta(obj) instead`

# Short Description
Add a short description describing the pull request (PR) here.

# Checklist before PR can be merged:
- [ ] closes issue #xxxx
- [ ] is documented
- [ ] Format code with [Black formatting](https://black.readthedocs.io)
- [ ] type hints for functions and methods
- [x] tests added / passed
- [ ] Example Notebook (for new features)
- [ ] Remove output for all notebooks with changes
