### PR TITLE
Geometry metadata in pas files

### DIFF
--- a/pastas/io/pas.py
+++ b/pastas/io/pas.py
@@ -78,7 +78,7 @@ class PastasEncoder(json.JSONEncoder):
     """
 
     def default(self, o):
-        if isinstance(o, (Timestamp, datetime.datetime)):
+        if isinstance(o, (Timestamp, datetime.datetime, datetime.date)):
             return o.isoformat()
         elif isinstance(o, Series):
             return o.to_json(date_format="iso", orient="split")

--- a/pastas/io/pas.py
+++ b/pastas/io/pas.py
@@ -11,6 +11,14 @@ from collections import OrderedDict
 from io import StringIO as stringIO
 from logging import getLogger
 
+try:
+    from shapely.geometry.base import BaseGeometry
+
+    SHAPELY = True
+except ModuleNotFoundError:
+    SHAPELY = False
+    BaseGeometry = None
+
 from pandas import (
     DataFrame,
     Series,
@@ -18,7 +26,6 @@ from pandas import (
     Timestamp,
     isna,
     read_json,
-    to_numeric,
     to_timedelta,
 )
 
@@ -90,6 +97,8 @@ class PastasEncoder(json.JSONEncoder):
             if isinstance(o, datetime.timedelta):
                 o = to_timedelta(o)
             return o.to_timedelta64().__str__()
+        elif SHAPELY and isinstance(o, BaseGeometry):
+            return o.wkt
         elif isna(o):
             return None
         else:


### PR DESCRIPTION
# Short Description
Not sure if this is something we want to support, but the change is minimal, and convenient if your metadata contains geometric objects. Also useful for pastastore :). 

# Checklist before PR can be merged:
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] tests added / passed
