### PR TITLE
Update logging messages and raising errors

### DIFF
--- a/doc/developers/code_style.rst
+++ b/doc/developers/code_style.rst
@@ -39,10 +39,34 @@ Private methods in Pastas are identified by a leading underscore. For example:
 This basically means that these methods may be removed or their behaviour may
 be changed without DeprecationWarning or any other form of notice.
 
-Logger Calls
-------------
+Logger Calls and Errors
+-----------------------
+
+A logger is used to provide information to the user and log info, warning, error
+messages. The logger is created using the `logging <https://docs.python.org/3/library/logging.html>`_
+module. The logger is created at the top of each file and can be imported in any module
+using:
+
+>>> import logging
+>>> logger = logging.getLogger(__name__)
+
+Info messages are logged using:
+
+>>> msg = "Message here, %s"
+>>> logger.info(msg, value)
+
 When a message to the logger is provided, it is important to use the
-s-string format (no f-strings) to prevent performance issues:
+s-string format (no f-strings) to prevent performance issues.
 
->>> logger.info("Message here: %s", value)
+Warning messages are logged using:
 
+>>>  logger.warning(msg, value)
+
+Error messages are logged, and raised using the appropriate error using:
+
+>>> logger.error(msg, value)
+>>> raise ValueError(msg % value)
+
+When raising an error, the error message should be provided in the logger.error method,
+and the error should be raised immediately after. This is to ensure that the error
+message is logged before the error is raised.

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -18,11 +18,9 @@ def set_parameter(function: Function) -> Function:
     @wraps(function)
     def _set_parameter(self, name: str, value: float, **kwargs):
         if name not in self.parameters.index:
-            logger.error(
-                "Parameter name %s does not exist, please choose from %s",
-                name,
-                self.parameters.index,
-            )
+            msg = "Parameter name %s does not exist, please choose from %s"
+            logger.error(msg, name, self.parameters.index)
+            raise KeyError(msg % (name, self.parameters.index))
         else:
             return function(self, name, value, **kwargs)
 
@@ -33,11 +31,12 @@ def get_stressmodel(function: Function) -> Function:
     @wraps(function)
     def _get_stressmodel(self, name: str, **kwargs):
         if name not in self.stressmodels.keys():
-            logger.error(
+            msg = (
                 "The stressmodel name you provided is not in the stressmodels dict. "
-                "Please select from the following list: %s",
-                self.stressmodels.keys(),
+                "Please select from the following list: %s"
             )
+            logger.error(msg, self.stressmodels.keys())
+            raise KeyError(msg % self.stressmodels.keys())
         else:
             return function(self, name, **kwargs)
 

--- a/pastas/extensions/accessor.py
+++ b/pastas/extensions/accessor.py
@@ -1,5 +1,7 @@
 # copied and adapted from pandas/core/accessor.py
-import warnings
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class CachedAccessor:
@@ -84,12 +86,11 @@ def _register_accessor(name: str, cls):
 
     def decorator(accessor):
         if hasattr(cls, name):
-            warnings.warn(
-                f"registration of accessor {repr(accessor)} under name "
-                f"{repr(name)} for type {repr(cls)} is overriding a preexisting "
-                "attribute with the same name.",
-                UserWarning,
+            msg = (
+                "registration of accessor %s under name %s for type %s is overriding"
+                " a preexisting attribute with the same name."
             )
+            logger.warning(msg, repr(accessor), repr(name), repr(cls))
         setattr(cls, name, CachedAccessor(name, accessor))
         cls._accessors.add(name)
         return accessor

--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -37,7 +37,9 @@ def load(fname: str, **kwargs) -> Model:
 
     """
     if not path.exists(fname):
-        logger.error("File not found: %s", fname)
+        msg = "File not found: %s"
+        logger.error(msg, fname)
+        raise FileNotFoundError(msg % fname)
 
     # Dynamic import of the export module
     load_mod = import_module(f"pastas.io{path.splitext(fname)[1]}")
@@ -49,12 +51,14 @@ def load(fname: str, **kwargs) -> Model:
 
     # A single catch for old pas-files, no longer supported
     if version.parse(file_version) < version.parse("0.23.0"):
-        raise UserWarning(
+        msg = (
             "This file was created with a Pastas version prior to 0.23 "
             "and cannot be loaded with Pastas >= 1.0. Please load and "
             "save the file with Pastas 0.23 first to update the file "
             "format."
         )
+        logger.error(msg)
+        raise ValueError(msg)
 
     ml = _load_model(data)
 

--- a/pastas/solver.py
+++ b/pastas/solver.py
@@ -351,8 +351,9 @@ class BaseSolver:
 
         if samples.shape[0] < n:
             logger.warning(
-                "Parameter sample size is smaller than n: "
-                f"{samples.shape[0]}/{n}. Increase 'max_iter'."
+                "Parameter sample size is smaller than n: %s/%s Increase 'max_iter'.",
+                samples.shape[0],
+                n,
             )
         return samples[:n, :]
 
@@ -1016,7 +1017,7 @@ class EmceeSolve(BaseSolver):
 
         if np.isnan(loc) or np.isnan(scale):
             msg = "Location and/or scale parameter is NaN."
-            logger.error(msg=msg)
+            logger.error(msg)
             raise ValueError(msg)
 
         return getattr(mod, dist)(loc=loc, scale=scale)
@@ -1066,7 +1067,7 @@ class EmceeSolve(BaseSolver):
         if name not in self.parameters.index:
             msg = "parameter %s is not present in the solver."
             self.logger.error(msg, name)
-            raise KeyError(msg, name)
+            raise KeyError(msg % name)
 
         # Set the initial value
         if initial is not None:

--- a/pastas/stats/signatures.py
+++ b/pastas/stats/signatures.py
@@ -482,7 +482,7 @@ def _colwell_components(
     else:
         msg = "freq %s is not a supported option."
         logger.error(msg, freq)
-        raise ValueError(msg)
+        raise ValueError(msg % freq)
 
     df["values"] = 1.0
     df = df.pivot_table(columns="head", index="time", aggfunc="sum", values="values")

--- a/pastas/stats/signatures.py
+++ b/pastas/stats/signatures.py
@@ -992,7 +992,7 @@ def reversals_avg(series: Series) -> float:
     # Check if the time step is approximately daily
     if not (dt > 0.9).all() & (dt < 1.1).all():
         msg = (
-            "The time step is not approximately daily (>10% of time steps are"
+            "The time step is not approximately daily (>10%% of time steps are"
             "non-daily). This may lead to incorrect results."
         )
         logger.warning(msg)
@@ -1275,10 +1275,10 @@ def recession_constant(
     # Return nan and raise warning if the decay constant is close to the boundary
     if isclose(popt[1], 0.0) or isclose(popt[1], 1e3):
         msg = (
-            "The estimated recession constant ({:.2f}) is close to the boundary. "
-            "This may lead to incorrect results.".format(popt[1])
+            "The estimated recession constant (%s) is close to the boundary. "
+            "This may lead to incorrect results."
         )
-        logger.warning(msg)
+        logger.warning(msg, round(popt[1], 2))
         return nan
     else:
         return popt[1]
@@ -1346,10 +1346,10 @@ def recovery_constant(
     # Return nan and raise warning if the recovery constant is close to the boundary
     if isclose(popt[1], 0.0) or isclose(popt[1], 1e3):
         msg = (
-            "The estimated recovery constant ({:.2f}) is close to the boundary. "
-            "This may lead to incorrect results.".format(popt[1])
+            "The estimated recovery constant (%s) is close to the boundary. "
+            "This may lead to incorrect results."
         )
-        logger.warning(msg)
+        logger.warning(msg, round(popt[1], 2))
         return nan
     else:
         return popt[1]

--- a/pastas/stats/tests.py
+++ b/pastas/stats/tests.py
@@ -249,7 +249,10 @@ def runs_test(series: Series, cutoff: str = "median") -> Tuple[float, float]:
     elif isinstance(cutoff, float):
         pass
     else:
-        raise NotImplementedError(f"Cutoff criterion {cutoff} is not " f"implemented.")
+        msg = """Cutoff criterion %s is not implemented. Cutoff should be 'mean',
+                 'median', or a float value."""
+        logger.error(msg, cutoff)
+        raise NotImplementedError(msg % cutoff)
 
     r[r > cutoff] = 1
     r[r < cutoff] = 0

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -55,9 +55,9 @@ def _frequency_is_supported(freq: str) -> str:
     try:
         Timedelta(offset)
     except:
-        msg = "Frequency {} not supported.".format(freq)
-        logger.error(msg)
-        raise ValueError(msg)
+        msg = "Frequency %s not supported."
+        logger.error(msg, freq)
+        raise ValueError(msg % freq)
     if offset.n == 1:
         freq = offset.name
     else:

--- a/pastas/utils.py
+++ b/pastas/utils.py
@@ -198,12 +198,13 @@ def validate_name(name: str, raise_error: bool = False) -> str:
     for char in ilchar:
         if char in name:
             msg = (
-                f"User-provided name '{name}' contains illegal character. Please "
-                f"remove '{char}' from name."
+                "User-provided name '%s' contains illegal character. Please "
+                "remove '%s' from name."
             )
             if raise_error:
-                raise Exception(msg)
+                logger.error(msg, name, char)
+                raise Exception(msg % (name, char))
             else:
-                logger.warning(msg)
+                logger.warning(msg, name, char)
 
     return name

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -21,7 +21,7 @@ def check_numba_scipy() -> bool:
     scipy_version_nsc = scipy_version_nsc[0].split(",")[0].split("=")[-1]
     if scipy_version > scipy_version_nsc:
         logger.warning(
-            f"numba_scipy supports SciPy<={scipy_version_nsc}, found {scipy_version}"
+            "numba_scipy supports SciPy<=%s, found %s", scipy_version_nsc, scipy_version
         )
         return False
     return True


### PR DESCRIPTION
# Short Description

In this PR the logging and error raising is made similar throughout Pastas, plus I described how this is done (for now). Even if we want to change this in the future that will be easier because it is all consistent throughout Pastas now.

- Use s-strings (logging module is optimized for that)
- raise errors after logging (so script terminates, but error is captured)
- Add description for developers in code_style.rst

See doc/developers/code_style.rst for a description of the proposed workflow for logging and raising errors.

# Checklist before PR can be merged:
- [x] closes issue #478
- [x] is documented
- [x] Format code with [Black formatting](https://black.readthedocs.io)
- [x] type hints for functions and methods
- [x] tests added / passed
