### PR TITLE
fix link to documentation in pyproj

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 [project.urls]
 homepage = "https://pastas.dev"
 repository = "https://github.com/pastas/pastas"
-documentation = "https://pastas.readthedocs.io/en/latest/"
+documentation = "https://pastas.readthedocs.io/latest/"
 
 [project.optional-dependencies]
 solvers = ["lmfit >= 1.0.0", "emcee >= 3.0"]


### PR DESCRIPTION
# Short Description
fix link to documentation in pyproj. Hopefully this will fix the link in PyPi after the next release.

# Checklist before PR can be merged:
- [ ] closes issue #748