### PR TITLE
Allow pcov of solver to be null when reading a pas-file. 

### DIFF
--- a/pastas/io/pas.py
+++ b/pastas/io/pas.py
@@ -58,10 +58,13 @@ def pastas_hook(obj: dict):
             else:
                 obj[key] = Timedelta(value)
         elif key in ["parameters", "pcov"]:
-            # Necessary to maintain order when using the JSON format!
-            value = json.loads(value, object_pairs_hook=OrderedDict)
-            param = DataFrame(data=value, columns=value.keys()).T
-            obj[key] = param.infer_objects()
+            if value is not None:
+                # Necessary to maintain order when using the JSON format!
+                value = json.loads(value, object_pairs_hook=OrderedDict)
+                param = DataFrame(data=value, columns=value.keys()).T
+                obj[key] = param.infer_objects()
+            else:
+                obj[key] = value
         else:
             try:
                 obj[key] = json.loads(value, object_hook=pastas_hook)


### PR DESCRIPTION
# Short Description
The pcov attribute of the BaseSolver class is None by default. However, when the model is stored with this solver in a pas-file, the file cannot be read anymore because a DataFrame is expected for the pcov attribute. This pr allows the default value (None=null) to be accepted as well. 