### PR TITLE
Increase min_obs for acf for irregular time series to 50

### DIFF
--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -37,7 +37,7 @@ def acf(
     bin_method: str = "rectangle",
     bin_width: float = 0.5,
     max_gap: float = inf,
-    min_obs: int = 20,
+    min_obs: int = 50,
     full_output: bool = False,
     alpha: float = 0.05,
 ) -> Union[Series, DataFrame]:
@@ -121,7 +121,7 @@ def ccf(
     bin_method: str = "rectangle",
     bin_width: float = 0.5,
     max_gap: float = inf,
-    min_obs: int = 20,
+    min_obs: int = 50,
     full_output: bool = False,
     alpha: float = 0.05,
 ) -> Union[Series, DataFrame]:
@@ -242,13 +242,13 @@ def _compute_ccf_rectangle(
                 d = abs(t_x[i] - t_y[j]) - lags[k]
                 if abs(d) <= bin_width:
                     cl += x[i] * y[j]
-                    b_sum += 1
+                    b_sum += 1.0
         if b_sum == 0.0:
             c[k] = nan
-            b[k] = 0.01  # Prevent division by zero error
+            b[k] = 1e-16  # Prevent division by zero error
         else:
             c[k] = cl / b_sum
-            b[k] = b_sum / 2  # divide by 2 because we over count in for-loop
+            b[k] = b_sum / 2.0  # divide by 2 because we over count in for-loop
     return c, b
 
 
@@ -281,10 +281,10 @@ def _compute_ccf_gaussian(
                 b_sum += d
         if b_sum == 0.0:
             c[k] = nan
-            b[k] = 0.01  # Prevent division by zero error
+            b[k] = 1e-16  # Prevent division by zero error
         else:
             c[k] = cl / b_sum
-            b[k] = b_sum / 2  # divide by 2 because we over count in for-loop
+            b[k] = b_sum / 2.0  # divide by 2 because we over count in for-loop
     return c, b
 
 


### PR DESCRIPTION
# Short Description

Increase the default value for min_obs, the minimum number of values that are needed to compute the autocorrelation function at a certain time lag. 

# Checklist before PR can be merged:
- [x] closes issue #810 
- [x] is documented
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [x] Remove output for all notebooks with changes
