### PR TITLE
Add brakenhoff 2022 and pastas papers for 2024

### DIFF
--- a/doc/about/publications.rst
+++ b/doc/about/publications.rst
@@ -11,6 +11,12 @@ a large number of non-published reports, partly listed in a `GitHub repo here <h
 Peer-reviewed publications
 --------------------------
 
+2024
+****
+.. bibliography:: publications.bib
+    :list: bullet
+    :filter: year == "2024"
+
 2023
 ****
 .. bibliography:: publications.bib

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -793,7 +793,7 @@ class WellModel(StressModelBase):
     This class implements convolution of multiple series with the same response
     function. This can be applied when dealing with multiple wells in a time series
     model. The distance(s) from the pumping well(s) to the monitoring well have to be
-    provided for each stress.
+    provided for each stress. See :cite:t:`brakenhoff_application_2022` for more details on the methods for this model.
 
     Only works with the HantushWellModel response function.
     """


### PR DESCRIPTION
# Short Description

Record the papers for 2024 on the docs website and add Brakenhoff et al to the WellModel

# Checklist before PR can be merged:
- [x] closes issue #809 
- [x] is documented
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [x] Remove output for all notebooks with changes
