### PR TITLE
Consistent ruff settings in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,6 @@ numbascipy = ["numba-scipy >= 0.3.1"]
 [tool.setuptools.dynamic]
 version = { attr = "pastas.version.__version__" }
 
-[tool.black]
-line-length = 88
-
-[tool.isort]
-profile = "black"
-
 [tool.ruff]
 extend-include = ["*.ipynb"]
 lint.extend-select = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ profile = "black"
 
 [tool.ruff]
 extend-include = ["*.ipynb"]
+lint.extend-select = ["I"]
+show-fixes = true
+fix = true
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --durations=0"


### PR DESCRIPTION
Make sure ruff settings in pyproject.toml are consistent with tests

Also remove old black and isort settings.