### PR TITLE
Load parameter bounds and vary if changed in pas file

### DIFF
--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -150,9 +150,15 @@ def _load_model(data: dict) -> Model:
     # Convert parameters to numeric
     ml.parameters = ml.parameters.infer_objects()
 
-    # When initial values changed
-    for param, value in ml.parameters.loc[:, "initial"].items():
-        ml.set_parameter(name=param, initial=value)
+    # When parameter initial values and bounds changed
+    for pname, data in ml.parameters.iterrows():
+        ml.set_parameter(
+            name=pname,
+            initial=data.at["initial"],
+            vary=data.at["vary"],
+            pmin=data.at["pmin"],
+            pmax=data.at["pmax"],
+        )
 
     return ml
 

--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -151,13 +151,13 @@ def _load_model(data: dict) -> Model:
     ml.parameters = ml.parameters.infer_objects()
 
     # When parameter initial values and bounds changed
-    for pname, data in ml.parameters.iterrows():
+    for pname, pdata in ml.parameters.iterrows():
         ml.set_parameter(
             name=pname,
-            initial=data.at["initial"],
-            vary=data.at["vary"],
-            pmin=data.at["pmin"],
-            pmax=data.at["pmax"],
+            initial=pdata.at["initial"],
+            vary=pdata.at["vary"],
+            pmin=pdata.at["pmin"],
+            pmax=pdata.at["pmax"],
         )
 
     return ml


### PR DESCRIPTION
# Short Description
Currently, if the `Model.parameters` `DataFrame` was changed in a .pas file only the initial parameters were reloaded correctly. The `pmin`, `pmax` and `vary` values were not parsed to the loaded model. Even though the values from the pas file were visible in the `ml.parameters` `DataFrame`, the old/default parameters were still present in the `ml.stressmodels[name].parameters` `DataFrame` because it was not loaded correctly. 

# Checklist before PR can be merged:
- [x] closes issue #826
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
