### PR TITLE
Set nlags for series shorter than 365 days

### DIFF
--- a/pastas/stats/tests.py
+++ b/pastas/stats/tests.py
@@ -390,7 +390,7 @@ def stoffer_toloi(
     de0 = dz0 / da0
 
     # initialize, compute all correlation up to one year.
-    nlags = 365  # Hard-coded for now
+    nlags = min(365, nobs - 1)
     dz = zeros(nlags)
     da = zeros(nlags)
     de = zeros(nlags)


### PR DESCRIPTION
# Short Description
As described in #854, this PR fixes a runtime warning for when `stoffer_toloi` test is run on a timeseries with less than 365 observations.

# Checklist before PR can be merged:
- [x] closes issue #854 
- [x] is documented
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
- [x] tests added / passed
