### PR TITLE
remove constraints for numba rc and py313

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
     "matplotlib >= 3.6.1",
     "pandas >= 2.1",
     "scipy >= 1.8.1, !=1.13.0",
-    "numba >= 0.55.2, < 0.61.0 ; python_version < '3.13'",
-    "numba >= 0.61.0rc2 ; python_version >= '3.13'",
+    "numba >= 0.55.2",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [
@@ -134,10 +133,5 @@ legacy_tox_ini = """
 
 [tool.codespell]
 skip = "*.pdf"
-ignore-regex = "[A-Za-z0-9+/]{100,}"  # base64-encoded data in *.ipynb files
-ignore-words-list = [
-    "delt",
-    "te",
-    "theses",
-    "Bilt",
-]
+ignore-regex = "[A-Za-z0-9+/]{100,}"                 # base64-encoded data in *.ipynb files
+ignore-words-list = ["delt", "te", "theses", "Bilt"]


### PR DESCRIPTION
# Short Description
Small PR for the new _numba_ version 0.61.0 released on 20-01-2024. Now people don't need to install the Numba release candidate any more when using Python 3.13.