### PR TITLE
Do not compute RMSN when no noise model is present in the model

### DIFF
--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -441,10 +441,17 @@ class Statistics:
 
         >>> ml.stats.summary(stats=["mae", "rmse"])
         """
+
         if stats is None:
             stats_to_compute = self.ops
         else:
             stats_to_compute = stats
+
+        # Remove rmsn if no noise model
+        if "rmsn" in stats_to_compute and not (
+            self.ml.noisemodel and self.ml.settings["noise"]
+        ):
+            stats_to_compute.remove("rmsn")
 
         stats = DataFrame(columns=["Value"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,14 @@ def ml() -> ps.Model:
 
 
 @pytest.fixture
+def ml_no_noisemodel() -> ps.Model:
+    ml = ps.Model(obs, name="Test_Model")
+    sm = ps.RechargeModel(prec=rain, evap=evap, rfunc=ps.Gamma(), name="rch")
+    ml.add_stressmodel(sm)
+    return ml
+
+
+@pytest.fixture
 def ml_sm() -> ps.Model:
     ml_sm = ps.Model(obs.dropna(), name="Test_Model")
     ml_sm.add_noisemodel(ps.ArNoiseModel())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -156,7 +156,7 @@ def test_model_sim_w_nans_error(ml_no_settings):
 def test_modelstats(ml: ps.Model) -> None:
     ml.del_noisemodel()
     ml.solve()
-    summary = ml.stats.summary()   
+    summary = ml.stats.summary()
     assert not summary.isnull().values.any(), "Nan value in summary"
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -154,8 +154,10 @@ def test_model_sim_w_nans_error(ml_no_settings):
 
 
 def test_modelstats(ml: ps.Model) -> None:
+    ml.del_noisemodel()
     ml.solve()
-    ml.stats.summary()
+    summary = ml.stats.summary()   
+    assert not summary.isnull().values.any(), "Nan value in summary"
 
 
 def test_fit_report(ml: ps.Model) -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -154,9 +154,14 @@ def test_model_sim_w_nans_error(ml_no_settings):
 
 
 def test_modelstats(ml: ps.Model) -> None:
-    ml.del_noisemodel()
     ml.solve()
     summary = ml.stats.summary()
+    assert not summary.isnull().values.any(), "Nan value in summary"
+
+
+def test_modelstats_no_noisemodel(ml_no_noisemodel: ps.Model) -> None:
+    ml_no_noisemodel.solve()
+    summary = ml_no_noisemodel.stats.summary()
     assert not summary.isnull().values.any(), "Nan value in summary"
 
 


### PR DESCRIPTION
Issue is solved, added a test to check if there are NaN values in the stats summary.
A test model without the noise model would be needed. Thanks

[ ] Closes issue #819 


