### PR TITLE
Use decorator to copy the docs from one method to another

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -190,6 +190,7 @@ def latexfun(
 
     return latexify_decorator
 
+
 def documented_by(original: Optional[Function] = None) -> Function:
     def wrapper(target):
         target.__doc__ = original.__doc__

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -189,3 +189,10 @@ def latexfun(
         return latexify_decorator(function)
 
     return latexify_decorator
+
+def documented_by(original: Optional[Function] = None) -> Function:
+    def wrapper(target):
+        target.__doc__ = original.__doc__
+        return target
+
+    return wrapper

--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -481,4 +481,3 @@ class Statistics:
         return diagnostics(
             series=series, alpha=alpha, nparam=nparam, stats=stats, float_fmt=float_fmt
         )
-

--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -30,7 +30,7 @@ from pandas import DataFrame
 
 from pastas.typing import Model, TimestampType
 
-from .decorators import model_tmin_tmax
+from .decorators import documented_by, model_tmin_tmax
 from .stats import diagnostics, metrics
 
 
@@ -461,6 +461,7 @@ class Statistics:
         stats.index.name = "Statistic"
         return stats
 
+    @documented_by(diagnostics)
     @model_tmin_tmax
     def diagnostics(
         self,
@@ -480,3 +481,4 @@ class Statistics:
         return diagnostics(
             series=series, alpha=alpha, nparam=nparam, stats=stats, float_fmt=float_fmt
         )
+


### PR DESCRIPTION
# Short Description
This PR adds a docstring to ml.stats.diagnostics via a decorator. Not good for VScode, but good for the docs and works as soon as the code is run. So instead of copying the exact same docstring around I think this is the best option, but open for alternatives.

# Checklist before PR can be merged:
- [x] closes issue #866
- [x] is documented
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
- [x] tests added / passed
