### PR TITLE
Add stderr to results plots in Bokeh and Plotly

### DIFF
--- a/pastas/plotting/bokeh.py
+++ b/pastas/plotting/bokeh.py
@@ -112,7 +112,9 @@ class Bokeh:
             show(p)
         return p
 
-    def results(self, tmin=None, tmax=None, height=500, width=800, show_plot=True):
+    def results(
+        self, tmin=None, tmax=None, height=500, width=800, show_plot=True, stderr=False
+    ):
         """Overview of the results of the pastas model.
 
         Parameters
@@ -127,6 +129,8 @@ class Bokeh:
            width of the plot, by default 800
         show_plot : bool, optional
             Show the plot (i.e., in Jupyter Notebooks), by default True
+        stderr : bool, optional
+            Show the standard error of the parameters, by default False
 
         Returns
         -------
@@ -225,6 +229,15 @@ class Bokeh:
                 formatter=ScientificFormatter(precision=2),
             ),
         ]
+        if stderr:
+            columns.append(
+                TableColumn(
+                    field="stderr",
+                    title="Stderr",
+                    formatter=ScientificFormatter(precision=2),
+                )
+            )
+
         table = DataTable(
             source=df,
             columns=columns,

--- a/pastas/plotting/bokeh.py
+++ b/pastas/plotting/bokeh.py
@@ -216,7 +216,7 @@ class Bokeh:
         res_plot.legend.ncols = 2
 
         # Parameter Table
-        df = ColumnDataSource(self._model.parameters.loc[:, ["optimal"]])
+        df = ColumnDataSource(self._model.parameters.loc[:, ["optimal", "stderr"]])
         columns = [
             TableColumn(
                 field="index",


### PR DESCRIPTION
# Short Description

Quick fix to allow stderr as an argument to the interactive results plots. 

# Checklist before PR can be merged:
- [x] closes issue #744
- [x] is documented
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
- [x] type hints for functions and methods
- [x] tests added / passed
- [x] Example Notebook (for new features)
- [x] Remove output for all notebooks with changes
