### PR TITLE
Add normalized Nash-Sutcliffe Efficiency

### DIFF
--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -184,7 +184,7 @@ class Statistics:
         weighted: bool = False,
         **kwargs,
     ) -> float:
-        """Nash-Sutcliffe coefficient for model fit .
+        """Nash-Sutcliffe Efficiency for model fit .
 
         Parameters
         ----------
@@ -201,6 +201,33 @@ class Statistics:
         res = self.ml.residuals(tmin=tmin, tmax=tmax)
         obs = self.ml.observations(tmin=tmin, tmax=tmax)
         return metrics.nse(obs=obs, res=res, weighted=weighted, **kwargs)
+
+    @model_tmin_tmax
+    def nnse(
+        self,
+        tmin: Optional[TimestampType] = None,
+        tmax: Optional[TimestampType] = None,
+        weighted: bool = False,
+        **kwargs,
+    ) -> float:
+        """Normalized Nash-Sutcliffe Efficiency for model fit .
+
+        Parameters
+        ----------
+        tmin: str or pandas.Timestamp, optional
+        tmax: str or pandas.Timestamp, optional
+        weighted: bool, optional
+            If weighted is True, the variances are computed using the time step
+            between observations as weights. Default is False.
+
+        See Also
+        --------
+        pastas.stats.nnse
+        """
+        res = self.ml.residuals(tmin=tmin, tmax=tmax)
+        obs = self.ml.observations(tmin=tmin, tmax=tmax)
+
+        return metrics.nnse(obs=obs, res=res, weighted=weighted, **kwargs)
 
     @model_tmin_tmax
     def pearsonr(

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -390,6 +390,9 @@ def nnse(
 
     .. math:: \\text{NNSE} = 1 / (2 - NSE)
 
+    This metric normalizes the NSE between ~0 and 1 instead of -infinity and 1.
+    So the optimal value for NNSE is 1, same as the NSE. However, an NNSE value
+    of 0.5 corresponds to an NSE of 0, while the worst possible NNSE value is ~0.
     """
     nnse = 1 / (
         2

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -27,6 +27,7 @@ __all__ = [
     "sse",
     "mae",
     "nse",
+    "nnse",
     "evp",
     "rsq",
     "bic",
@@ -351,6 +352,57 @@ def nse(
     mu = average(obs.to_numpy(), weights=w)
 
     return 1 - (w * err.to_numpy() ** 2).sum() / (w * (obs.to_numpy() - mu) ** 2).sum()
+
+
+def nnse(
+    obs: Series,
+    sim: Optional[Series] = None,
+    res: Optional[Series] = None,
+    missing: str = "drop",
+    weighted: bool = False,
+    max_gap: int = 30,
+) -> float:
+    """Compute the (weighted) Normalized Nash-Sutcliffe Efficiency (NNSE).
+
+    Parameters
+    ----------
+    obs: pandas.Series
+        Series with the observed values.
+    sim: pandas.Series, optional
+        The Series with the simulated values.
+    res: pandas.Series, optional
+        The Series with the residual values. If time series for the residuals are
+        provided, the sim and obs arguments are ignored. Note that the residuals
+        must be computed as `obs - sim` here.
+    missing: str, optional
+        string with the rule to deal with missing values. Only "drop" is supported now.
+    weighted: bool, optional
+        If weighted is True, the variances are computed using the time step between
+        observations as weights. Default is False.
+    max_gap: int, optional
+        maximum allowed gap period in days to use for the computation of the weights.
+        All time steps larger than max_gap are replace with the max_gap value.
+        Default value is 30 days.
+
+    Notes
+    -----
+    NNSE computed according to :cite:t:`nash_normalized_2006`
+
+    .. math:: \\text{NNSE} = 1 / (2 - NSE)
+
+    """
+    nnse = 1 / (
+        2
+        - nse(
+            obs=obs,
+            sim=sim,
+            res=res,
+            missing=missing,
+            weighted=weighted,
+            max_gap=max_gap,
+        )
+    )
+    return nnse
 
 
 def rsq(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -36,12 +36,12 @@ def test_evp():
 
 def test_nse():
     nse = ps.stats.metrics.nse(obs=obs, sim=sim)
-    assert pytest.approx(nse, tol) == 0.99855
+    assert pytest.approx(nse, tol) == 0.998550
 
 
 def test_nnse():
     nnse = ps.stats.metrics.nnse(obs=obs, sim=sim)
-    assert pytest.approx(nnse, tol) == 0.99855
+    assert pytest.approx(nnse, tol) == 0.998552
 
 
 def test_rsq():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,6 +39,11 @@ def test_nse():
     assert pytest.approx(nse, tol) == 0.99855
 
 
+def test_nnse():
+    nnse = ps.stats.metrics.nnse(obs=obs, sim=sim)
+    assert pytest.approx(nnse, tol) == 0.99855
+
+
 def test_rsq():
     rsq = ps.stats.metrics.rsq(obs=obs, sim=sim)
     assert pytest.approx(rsq, tol) == 0.99855


### PR DESCRIPTION
# Short Description
Add normalized Nash-Sutcliffe Efficience to `pastas.stats.metrics`.

# Checklist before PR can be merged:
- [x] closes issue #888 
- [x] is documented
- [x] Format code with [ruff formatting](https://docs.astral.sh/ruff/)
- [x] type hints for functions and methods
- [x] tests added / passed
