### PR TITLE
CCF improvements

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -146,7 +146,7 @@ def deprecate_args_or_kwargs(
         raise DeprecationWarning(msg)
 
 
-def njit(function: Optional[Function] = None, parallel: bool = False) -> Function:
+def njit(function: Optional[Function] = None, **kwargs) -> Function:
     def njit_decorator(f: Function):
         try:
             if not USE_NUMBA:
@@ -154,7 +154,7 @@ def njit(function: Optional[Function] = None, parallel: bool = False) -> Functio
             else:
                 from numba import njit
 
-                fnumba = njit(f, parallel=parallel)
+                fnumba = njit(f, **kwargs)
                 return fnumba
         except ImportError:
             return f

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -223,7 +223,7 @@ def ccf(
     elif bin_method == "gaussian":
         c, b = _compute_ccf_gaussian(lags, t_x, x, t_y, y, bin_width)
     elif bin_method == "regular":
-        c, b = _compute_ccf_regular(arange(1.0, len(lags) + 1), x, y)
+        c, b = _compute_ccf_regular(arange(0, len(lags), dtype=float), x, y)
     else:
         raise NotImplementedError
 

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -244,7 +244,10 @@ def ccf(
     result = result.where(result.n > min_obs).dropna()
 
     # Raise a warning if the correlation is above 1 or below -1
-    if (result.ccf > 1).any() or (result.ccf < -1).any():
+    # NOTE: Using 1.01 to avoid excessive warnings when using binning methods for
+    # irregular timesteps. In those cases correlations sometimes exceed 1 by a small
+    # amount.
+    if (result.ccf.abs() > 1.01).any():
         msg = (
             "The correlation is above 1 or below -1. This can occur due to the "
             "binning method used. Please check the data and the binning method and "

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -348,13 +348,12 @@ def _compute_ccf_gaussian(
     return c, b
 
 
-@njit(parallel=False, nogil=False, cache=False)
 def _compute_ccf_regular(
     lags: ArrayLike, x: ArrayLike, y: ArrayLike
 ) -> Tuple[ArrayLike, ArrayLike]:
     c = empty_like(lags)
     n = len(x)
-    for i in prange(len(lags)):
+    for i in range(len(lags)):
         lag = int(lags[i])
         if lag < n:
             # flip x, y to match numpy/scipy correlate output order

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -117,7 +117,10 @@ def acf(
         full_output=full_output,
         alpha=alpha,
         fallback_bin_method=fallback_bin_method,
-    ).iloc[1:]  # drop first value, which is always 1
+    )
+    # drop value for lag=0 by default, unless explicitly included
+    if c.index[0] == Timedelta(0) and isinstance(lags, int):
+        c = c.drop(c.index[0])
     c.name = "ACF"
     if full_output:
         return c.rename(columns={"ccf": "acf"})

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -291,10 +291,12 @@ def _compute_ccf_rectangle(
         lag_k = lags[k]
         # traverse the lower diagonal of NxN matrix: np.dot(x.T, y)
         for j in range(n):
+            yj = y[j]
+            t_yj = t_y[j]
             for i in range(j, n):
-                d = abs(t_x[i] - t_y[j]) - lag_k
+                d = abs(t_x[i] - t_yj) - lag_k
                 if abs(d) <= bin_width:
-                    cl += x[i] * y[j]
+                    cl += x[i] * yj
                     b_sum += 1.0
         if b_sum == 0.0:
             c[k] = nan
@@ -321,17 +323,22 @@ def _compute_ccf_gaussian(
 
     den1 = -2 * bin_width**2  # denominator 1
     den2 = sqrt(2 * pi * bin_width)  # denominator 2
-
+    six_den2 = 6 * den2  # six std. dev.
     for k in prange(len(lags)):
         cl = 0.0
         b_sum = 0.0
         lag_k = lags[k]
         # traverse the lower diagonal of NxN matrix: np.dot(x.T, y)
         for j in range(n):
+            t_yj = t_y[j]
+            yj = y[j]
             for i in range(j, n):
-                d = exp((t_x[i] - t_y[j] - lag_k) ** 2 / den1) / den2
-                cl += x[i] * y[j] * d
-                b_sum += d
+                dtlag = t_x[i] - t_yj - lag_k
+                if abs(dtlag) < six_den2:
+                    d = exp(dtlag**2 / den1) / den2
+                    # if d > 1e-5:
+                    cl += x[i] * yj * d
+                    b_sum += d
         if b_sum == 0.0:
             c[k] = nan
             b[k] = 1e-16  # Prevent division by zero error

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -348,7 +348,7 @@ def _compute_ccf_gaussian(
     return c, b
 
 
-@njit(parallel=True, nogil=True, cache=True)
+@njit(parallel=False, nogil=False, cache=False)
 def _compute_ccf_regular(
     lags: ArrayLike, x: ArrayLike, y: ArrayLike
 ) -> Tuple[ArrayLike, ArrayLike]:

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -217,6 +217,10 @@ def ccf(
         lags = arange(0, lags + 1, dtype=float)
     elif isinstance(lags, list):
         lags = array(lags, dtype=float)
+    elif isinstance(lags, ndarray):
+        # ensure dtype float otherwise numba will
+        # create integer arrays for the results
+        lags = lags.astype(float)
 
     if bin_method == "rectangle":
         c, b = _compute_ccf_rectangle(lags, t_x, x, t_y, y, bin_width)

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -117,7 +117,7 @@ def acf(
         full_output=full_output,
         alpha=alpha,
         fallback_bin_method=fallback_bin_method,
-    )
+    ).iloc[1:]  # drop first value, which is always 1
     c.name = "ACF"
     if full_output:
         return c.rename(columns={"ccf": "acf"})
@@ -212,9 +212,9 @@ def ccf(
     dt_mu = max(dt_x_mu, dt_y_mu)  # The mean time step from both series
 
     if isinstance(lags, int) and bin_method == "regular":
-        lags = arange(int(dt_mu), lags + 1, int(dt_mu), dtype=float)
+        lags = arange(0, lags, int(dt_mu), dtype=float)
     elif isinstance(lags, int):
-        lags = arange(1.0, lags + 1, dtype=float)
+        lags = arange(0, lags + 1, dtype=float)
     elif isinstance(lags, list):
         lags = array(lags, dtype=float)
 

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -215,7 +215,7 @@ def ccf(
     dt_mu = max(dt_x_mu, dt_y_mu)  # The mean time step from both series
 
     if isinstance(lags, int) and bin_method == "regular":
-        lags = arange(0, lags, int(dt_mu), dtype=float)
+        lags = arange(0, lags + 1, int(dt_mu), dtype=float)
     elif isinstance(lags, int):
         lags = arange(0, lags + 1, dtype=float)
     elif isinstance(lags, list):
@@ -230,7 +230,7 @@ def ccf(
     elif bin_method == "gaussian":
         c, b = _compute_ccf_gaussian(lags, t_x, x, t_y, y, bin_width)
     elif bin_method == "regular":
-        c, b = _compute_ccf_regular(arange(0, len(lags), dtype=float), x, y)
+        c, b = _compute_ccf_regular(lags, x, y)
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
This PR introduces some breaking changes, and I'm not sure how to deal with that:
 - Previous code `ps.stats.ccf(a, b)` is now calculated as `ps.stats.ccf(b, a)`. Do we add a warning?
 - The 0 lag for the ccf is returned. I think it's okay to just return the new result. 

The ACF is unaffected. One slight issue is that I'm getting ACFs > 1.0 warnings in the autocorrelation notebook. The max exceedance is <1e-3 so it's a computational issue having to do with the binning methods, as the current warning suggests. Not sure what to do about that...  

I don't think many people will be affected by these breaking changes since I don't think many people were actively using the CCF except for computing the autocorrelation, which is unchanged. So I think it would be okay to include these changes, and perhaps include a warning for flipped order of x and y.

# Short description
Deals with the following issues:
- #846 
- #912 
- #915 
- #917

### Lag 0 for CCF
Lag 0 for the CCF is now returned. In `ps.stats.acf()` this value is dropped if lags is passed as an integer. 

### Flip order of x, y to match numpy/scipy.correlate

The results now match numpy/scipy: `ps.stats.ccf(a, b)` is similar to `np.correlate(a, b, mode="full")[len(a) - 1:]`

### Performance
Improves performance considerably:
- Traverse only the lower diagonal of the dot product between x and y, in other words only consider the lags in one direction.
- In `_compute_ccf_gaussian`, check whether abs(time lag) is smaller than 6 *  std.dev. Beyond that limit the computed weight becomes negligible. See comment below.
- Use `numba.prange` for the outer loop
- Set `parallel=True, nogil=True, cache=True` in `@njit` decorator.
- Minor performance improvements (e.g. array access once per loop, etc.).

Many thanks @AviadAvr for suggesting the implementation of `numba.prange`!

Timings (N=1000, lags=365):
For `_compute_ccf_regular()`
```
Original       : 26.2 ms ± 1.6 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
This PR        : 4.25 ms ± 5.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <-- I reverted this change
Pastas plugins : 993 µs ± 133 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
EDIT: unfortunately, `njit`-ing the `_compute_ccf_regular` made it rather flaky. I was getting significant speedups, but the `test_acf_hourly` went from very fast to ~15s. So I reverted that change. For very fast CCFS for time series with regular timesteps `pastas_plugins` is recommended. 


For `_compute_ccf_gaussian()`
```
Original       : 4.51 s ± 69.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
This PR        : 559 ms ± 16.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

For `_compute_ccf_rectangle()`
```
Original       : 248 ms ± 1.85 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
This PR        : 56.1 ms ± 1.86 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

# Checklist before PR can be merged:
- [x] closes issues
   - [x] #846 
   - [x] #912 
   - [x] #915 
   - [x] #917
- [x] is documented
- [x] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [x] type hints
- [x] tests added or expanded