### PR TITLE
add warning for response > warmup to fit_report

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -165,6 +165,10 @@ def test_fit_report(ml: ps.Model) -> None:
     ml.fit_report(corr=True, stderr=True)
 
 
+def test_response_tmax_warnings_fit_report(ml: ps.Model) -> None:
+    ml.solve(warmup=1, tmin="2010", tmax="2011")
+
+
 def test_model_freq_geq_daily(prec: Series, evap: Series) -> None:
     rf_rch = ps.Exponential()
     A_rch = 800


### PR DESCRIPTION
- addresses #784

Produces the following at the bottom of the fit_report.
```
Warnings! (2)
===============================================
Response tmax for 'recharge' > than calibration period.
Response tmax for 'recharge' > than warmup period.
```

Perhaps we can rewrite some of these checks to use the `ps.check` functionality but that's a separate issue in my opinion. 

# Checklist before PR can be merged:
- [x] closes issue #784
- [x] is documented
- [x] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [x] tests added or expanded