### PR TITLE
fix for #1003

### DIFF
--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -335,17 +335,19 @@ class Statistics:
         # Get simulation at the correct indices
         if self.ml.interpolate_simulation:
             # interpolate simulation to times of observations
-            sim_interpolated = Series(interp(
-                obs.index.asi8, sim.index.asi8, sim.values
-            ), index=obs.index)
+            sim_interpolated = Series(
+                interp(obs.index.asi8, sim.index.asi8, sim.values), index=obs.index
+            )
         else:
-
             # All the observation indexes are in the simulation
             sim_interpolated = sim.reindex(obs.index)
-        
 
         return metrics.kge(
-            obs=obs, sim=sim_interpolated, weighted=weighted, modified=modified, **kwargs
+            obs=obs,
+            sim=sim_interpolated,
+            weighted=weighted,
+            modified=modified,
+            **kwargs,
         )
 
     @model_tmin_tmax

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -194,10 +194,10 @@ def pearsonr(
 
     Parameters
     ----------
-    sim: pandas.Series
-        The Series with the simulated values.
     obs: pandas.Series
         The Series with the observed values.
+    sim: pandas.Series
+        The Series with the simulated values.
     missing: str, optional
         string with the rule to deal with missing values in the observed series. Only
         "drop" is supported now.


### PR DESCRIPTION
When I solve a model with a frequency of `7D` -> `ml.solve(freq='7D')` and then compute the kge using `ml.kge()` I get an error. More info in this issue #1003.

The problem here is that the `kge` and `pearsonr` is required. The `pearsonr` is calculated from the observations and simulations. These are obtained using:
```
obs = self.ml.observations(tmin=tmin, tmax=tmax)
sim = self.ml.simulate(tmin=tmin, tmax=tmax)
```
Which works fine if the frequency is `D` but not for a frequency of `7D` because then `sim` and `obs` are different sizes. This same problem occurs when calculating residuals for models with a frequency of `7D`. So I think the solution is to do the same operation as for the residuals:
```
if self.interpolate_simulation:
    # interpolate simulation to times of observations
    sim_interpolated = np.interp(oseries_calib.index.asi8, sim.index.asi8, sim.values)
else:
    # All the observation indexes are in the simulation
    sim_interpolated = sim.reindex(oseries_calib.index)
```

Only the `kge` expects a series for sim so I modified this to:

```
# Get simulation at the correct indices
if self.ml.interpolate_simulation:
    # interpolate simulation to times of observations
    sim_interpolated = Series(interp(obs.index.asi8, sim.index.asi8, sim.values), index=obs.index)
else:
    # All the observation indexes are in the simulation
    sim_interpolated = sim.reindex(obs.index)
```

This seems to fix the problem although I think it is good of someone looks into this because I don't know if this is the best place to fix this.