### PR TITLE
Remove numba_step in Hantush rfuncs

### DIFF
--- a/pastas/version.py
+++ b/pastas/version.py
@@ -13,26 +13,6 @@ __version__ = "1.12.0b"
 pd_options.future.infer_string = True
 
 
-def check_numba_scipy() -> bool:
-    try:
-        import_module("numba_scipy")
-    except ImportError:
-        logger.warning(
-            "numba_scipy is not installed, defaulting to numpy implementation."
-        )
-        return False
-
-    scipy_version = metadata.version("scipy")
-    scipy_version_nsc = [x for x in metadata.requires("numba-scipy") if "scipy" in x]
-    scipy_version_nsc = scipy_version_nsc[0].split(",")[0].split("=")[-1]
-    if scipy_version > scipy_version_nsc:
-        logger.warning(
-            "numba_scipy supports SciPy<=%s, found %s", scipy_version_nsc, scipy_version
-        )
-        return False
-    return True
-
-
 def get_versions(
     optional: bool = False, lmfit: bool = False, latexify: bool = False
 ) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ rtd = [
     "myst_nb",
 ]
 dev = ["tox", "pre-commit", "pastas[ruffing,codespelling,ci,rtd]"]
-numbascipy = ["numba-scipy >= 0.3.1"]
 
 [tool.setuptools.dynamic]
 version = { attr = "pastas.version.__version__" }

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,25 +1,7 @@
 from typing import Any
 from unittest.mock import patch
 
-from pastas.version import check_numba_scipy, get_versions, show_versions
-
-
-def test_check_numba_scipy_not_installed() -> None:
-    with patch("importlib.import_module", side_effect=ImportError):
-        assert check_numba_scipy() is False
-
-
-def test_check_numba_scipy_version_mismatch() -> None:
-    with (
-        patch("importlib.import_module") as mock_import_module,
-        patch("importlib.metadata.version") as mock_version,
-        patch("importlib.metadata.requires") as mock_requires,
-    ):
-        mock_import_module.return_value = None
-        mock_version.side_effect = lambda x: "1.6.0" if x == "scipy" else None
-        mock_requires.return_value = ["scipy<=1.5.0"]
-
-        assert check_numba_scipy() is False
+from pastas.version import get_versions, show_versions
 
 
 def test_get_versions_basic() -> None:


### PR DESCRIPTION
# Short description
- remove logic to test scipy version and numba scipy
- remove numba step
- remove keyword arguments (no deprecation since no one was using this)

# Checklist before PR can be merged:
- [x] closes issue #980 
- [x] is documented
- [x] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [x] tests removed