### PR TITLE
Fix deprecation message for noisemodel usage

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -915,7 +915,7 @@ class Model:
                 msg = (
                     "To solve using a noisemodel, add a noisemodel to a "
                     "model called ml using ml.add_noisemodel(n), where n is an instance"
-                    "of a noisemodel (e.g., n = ps.ArNoiseModel()). See this issue on "
+                    " of a noisemodel (e.g., n = ps.ArNoiseModel()). See this issue on "
                     "GitHub for more information: "
                     "https://github.com/pastas/pastas/issues/735"
                 )


### PR DESCRIPTION
Corrected the message for adding a noisemodel in the documentation.

# Short description
Add a short description describing the pull request here.

# Checklist before PR can be merged:
- [ ] closes issue #xxxx
- [ ] is documented
- [ ] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [ ] type hints
- [ ] tests added or expanded
- [ ] remove output for all notebooks with changes
- [ ] example notebook (for new features)