### PR TITLE
Update numba dependencies by removing release candidate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
     "matplotlib >= 3.9.0",
     "pandas >= 2.2.2",
     "scipy >= 1.13.0",
-    "numba >= 0.60.0, < 0.63.0 ; python_version < '3.14'",
-    "numba >= 0.63.0b1 ; python_version == '3.14'",
+    "numba >= 0.60.0",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [


### PR DESCRIPTION
Allows full support for Python 3.14 and simplifies the dependencies again.

# Checklist before PR can be merged:
- [x] closes issue #999 