### PR TITLE
Update `PastasDeprecationWarning` and `deprecate_args_or_kwargs` with `DeprecationWarning` and `Attribute/TypeError`

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -175,14 +175,13 @@ def deprecate_args_or_kwargs(
     deprecate_version: str,
     remove_version: str,
     reason: str = "",
-    force_raise: bool = False,
 ):
     """Provide a warning or error when a function argument is deprecated.
 
     This function raises errors or warnings based on the current Pastas version and the
     deprecation timeline. The behavior is:
 
-    - If current version < deprecate_version: logs a warning (or raises if force_raise=True)
+    - If current version < deprecate_version: logs a warning
     - If deprecate_version <= current version < remove_version: raises DeprecationWarning
     - If current version >= remove_version: raises TypeError which indicates that it can be
     removed from the codebase entirely
@@ -198,15 +197,11 @@ def deprecate_args_or_kwargs(
     reason: str, optional
         The reason why the argument is deprecated, or a message directing users to
         an alternative. Default is an empty string.
-    force_raise: bool, optional
-        If True, raise DeprecationWarning immediately even if the current version has
-        not yet reached deprecate_version. Default is False.
 
     Raises
     ------
     DeprecationWarning
-        If between deprecate_version and remove_version (inclusive), or if force_raise=True
-        and current version < deprecate_version.
+        If between deprecate_version and remove_version and current version < deprecate_version.
     TypeError
         If current version >= remove_version and the argument is used.
     """
@@ -218,10 +213,7 @@ def deprecate_args_or_kwargs(
             f"The {name} argument is deprecated and will not be available"
             f" from Pastas version >={DEPRECATE_VERSION}. {reason}"
         )
-        if force_raise:
-            raise DeprecationWarning(msg)
-        else:
-            logger.warning(msg)
+        logger.warning(msg)
     elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
         raise TypeError("got an unexpected keyword argument '%s'" % name)
     else:

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -121,13 +121,12 @@ def PastasDeprecationWarning(version: str, reason: str = "") -> Any:
 
     - If current version < version: logs a warning and allows execution to continue
     - If current version >= version: raises AttributeError which indicates
-    that it can be removed from the codebase entirely
+    that it can be removed from the codebase entirely in the (near) future.
 
     Parameters
     ----------
     version: str
-        The version in which the function or class will be removed from the Pastas codebase
-        and raises an AttributeError.
+        The version in which the function, method or class raises an AttributeError.
     reason: str, optional
         The reason why the function or class is deprecated, or a message directing users
         to an alternative. Default is an empty string.
@@ -146,7 +145,7 @@ def PastasDeprecationWarning(version: str, reason: str = "") -> Any:
             if CURRENT_PASTAS_VERSION < VERSION:
                 msg = (
                     f"{name} is deprecated and will not be available "
-                    f"from Pastas version >={VERSION}. {reason}"
+                    f"from Pastas version >= {VERSION}. {reason}"
                 )
                 warn(message=msg, category=DeprecationWarning)
             else:
@@ -172,14 +171,14 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
 
     - If current version < version: logs a warning
     - If current version >= version: raises TypeError which indicates that it can be
-    removed from the codebase entirely
+    removed from the codebase entirely in the (near) future.
 
     Parameters
     ----------
     name: str
         The name of the argument that is deprecated.
     version: str
-        The version in which the argument will be removed and TypeError will be raised.
+        The version in which using the argument will raise a TypeError.
     reason: str, optional
         The reason why the argument is deprecated, or a message directing users to
         an alternative. Default is an empty string.
@@ -195,7 +194,7 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
     if CURRENT_PASTAS_VERSION < VERSION:
         msg = (
             f"The {name} argument is deprecated and will not be available"
-            f" from Pastas version >={VERSION}. {reason}"
+            f" from Pastas version >= {VERSION}. {reason}"
         )
         warn(message=msg, category=DeprecationWarning)
     else:

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -149,8 +149,8 @@ def PastasDeprecationWarning(
             REMOVE_VERSION = parse_version(remove_version)
             if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
                 msg = (
-                    f"{name} is deprecated and will not available anymore"
-                    f" in Pastas version {DEPRECATE_VERSION}. {reason}"
+                    f"{name} is deprecated and will not be available "
+                    f"from Pastas version >={DEPRECATE_VERSION}. {reason}"
                 )
                 logger.warning(msg)
             elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
@@ -214,7 +214,7 @@ def deprecate_args_or_kwargs(
 
     if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
         msg = (
-            f"The {name} argument is deprecated and will not available"
+            f"The {name} argument is deprecated and will not be available"
             f" from Pastas version >={DEPRECATE_VERSION}. {reason}"
         )
         if force_raise:
@@ -225,8 +225,8 @@ def deprecate_args_or_kwargs(
         raise TypeError("got an unexpected keyword argument '%s'" % name)
     else:
         msg = (
-            f"The {name} argument is deprecated and is not available "
-            f"since Pastas version {DEPRECATE_VERSION}. {reason}"
+            f"The {name} argument is deprecated and is not available"
+            f" since Pastas version {DEPRECATE_VERSION}. {reason}"
         )
         raise DeprecationWarning(msg)
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -112,7 +112,9 @@ def model_tmin_tmax(function: Callable) -> Callable:
     return _model_tmin_tmax
 
 
-def PastasDeprecationWarning(deprecate_version: str, remove_version: str, reason: str = "") -> Any:
+def PastasDeprecationWarning(
+    deprecate_version: str, remove_version: str, reason: str = ""
+) -> Any:
     """Provide a warning or error when a Pastas class, method or function is deprecated.
 
     This decorator manages deprecation of classes, functions, or methods across Pastas versions.
@@ -168,7 +170,11 @@ def PastasDeprecationWarning(deprecate_version: str, remove_version: str, reason
 
 
 def deprecate_args_or_kwargs(
-    name: str, deprecate_version: str, remove_version: str, reason: str = "", force_raise: bool = False
+    name: str,
+    deprecate_version: str,
+    remove_version: str,
+    reason: str = "",
+    force_raise: bool = False,
 ):
     """Provide a warning or error when a function argument is deprecated.
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -112,38 +112,52 @@ def model_tmin_tmax(function: Callable) -> Callable:
     return _model_tmin_tmax
 
 
-def PastasDeprecationWarning(remove_version: str, reason: str = "") -> Any:
+def PastasDeprecationWarning(deprecate_version: str, remove_version: str, reason: str = "") -> Any:
     """Provide a warning or error when a Pastas class, method or function is deprecated.
 
-    Logs a warning if the current Pastas version is lower than the version in which the
-    class, function or method is removed. Raises a DeprecationWarning if the current
-    Pastas version is higher than the version in which the class, function or method was
-    removed.
+    This decorator manages deprecation of classes, functions, or methods across Pastas versions.
+    The behavior depends on the current version:
+
+    - If current version < deprecate_version: logs a warning and allows execution to continue
+    - If deprecate_version <= current version < remove_version: raises DeprecationWarning
+    - If current version >= remove_version: raises ModuleNotFoundError which indicates
+    that it can be removed from the codebase entirely
 
     Parameters
     ----------
+    deprecate_version: str
+        The version in which the function or class begins raising a DeprecationWarning.
     remove_version: str
-        The version in which the function or class will be removed.
+        The version in which the function or class will be removed from Pastas and raise ModuleNotFoundError.
     reason: str, optional
-        The reason why the function or class is deprecated. Or provide a message
-        that tells the user which alternative should be used.
+        The reason why the function or class is deprecated, or a message directing users
+        to an alternative. Default is an empty string.
+
+    Returns
+    -------
+    callable
+        A decorator that wraps the target class or function.
     """
 
     def wrapper(obj: Any):
         name = obj.__name__
 
         def _function(*args, **kwargs):
-            if CURRENT_PASTAS_VERSION < parse_version(remove_version):
+            DEPRECATE_VERSION = parse_version(deprecate_version)
+            REMOVE_VERSION = parse_version(remove_version)
+            if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
                 msg = (
-                    "%s is deprecated and will be removed in Pastas version %s. "
-                    % (name, remove_version)
-                ) + reason
+                    f"{name} is deprecated and will not available anymore"
+                    f" in Pastas version {DEPRECATE_VERSION}. {reason}"
+                )
                 logger.warning(msg)
+            elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
+                raise ModuleNotFoundError("no module named '%s'" % name)
             else:
                 msg = (
-                    "%s is deprecated and was removed in Pastas version %s. "
-                    % (name, remove_version)
-                ) + reason
+                    f"{name} is deprecated and is not available since"
+                    f" Pastas version {DEPRECATE_VERSION}. {reason}"
+                )
                 raise DeprecationWarning(msg)
 
             return obj(*args, **kwargs)
@@ -154,41 +168,60 @@ def PastasDeprecationWarning(remove_version: str, reason: str = "") -> Any:
 
 
 def deprecate_args_or_kwargs(
-    name: str, remove_version: str, reason: str = "", force_raise: bool = False
+    name: str, deprecate_version: str, remove_version: str, reason: str = "", force_raise: bool = False
 ):
     """Provide a warning or error when a function argument is deprecated.
+
+    This function raises errors or warnings based on the current Pastas version and the
+    deprecation timeline. The behavior is:
+
+    - If current version < deprecate_version: logs a warning (or raises if force_raise=True)
+    - If deprecate_version <= current version < remove_version: raises DeprecationWarning
+    - If current version >= remove_version: raises TypeError which indicates that it can be
+    removed from the codebase entirely
 
     Parameters
     ----------
     name: str
         The name of the argument that is deprecated.
+    deprecate_version: str
+        The version in which the argument becomes deprecated.
     remove_version: str
-        The version in which the argument will be removed.
+        The version in which the argument will be removed and TypeError will be raised.
     reason: str, optional
-        The reason why the argument is deprecated. Or provide a message that tells the
-        user which alternative should be used.
+        The reason why the argument is deprecated, or a message directing users to
+        an alternative. Default is an empty string.
     force_raise: bool, optional
-        If True, raise a DeprecationWarning even if remove_version is still in the
-        future. Default is False.
-    """
-    if (not force_raise) and (CURRENT_PASTAS_VERSION < parse_version(remove_version)):
-        msg = (
-            "The '%s' argument is deprecated and will be removed in Pastas version %s. "
-            % (name, remove_version)
-        ) + reason
-        logger.warning(msg)
-    else:
-        if force_raise:
-            msg = (
-                "The %s argument is deprecated and will be removed in Pastas version %s. "
-                % (name, remove_version)
-            ) + reason
-        else:
-            msg = (
-                "The %s argument is deprecated and was removed in Pastas version %s. "
-                % (name, remove_version)
-            ) + reason
+        If True, raise DeprecationWarning immediately even if the current version has
+        not yet reached deprecate_version. Default is False.
 
+    Raises
+    ------
+    DeprecationWarning
+        If between deprecate_version and remove_version (inclusive), or if force_raise=True
+        and current version < deprecate_version.
+    TypeError
+        If current version >= remove_version and the argument is used.
+    """
+    DEPRECATE_VERSION = parse_version(deprecate_version)
+    REMOVE_VERSION = parse_version(remove_version)
+
+    if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
+        msg = (
+            f"The {name} argument is deprecated and will not available"
+            f" anymore in Pastas version {DEPRECATE_VERSION}. {reason}"
+        )
+        if force_raise:
+            raise DeprecationWarning(msg)
+        else:
+            logger.warning(msg)
+    elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
+        raise TypeError("got an unexpected keyword argument '%s'" % name)
+    else:
+        msg = (
+            f"The {name} argument is deprecated and is not available "
+            f"anymore since Pastas version {DEPRECATE_VERSION}. {reason}"
+        )
         raise DeprecationWarning(msg)
 
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -9,10 +9,9 @@ from contextlib import contextmanager
 from functools import wraps
 from logging import getLogger
 from typing import Any
-
+from warnings import warn
 from packaging.version import parse as parse_version
 from pandas import Timestamp
-from typing_extensions import deprecated  # available in warnings from python 3.13
 
 from pastas.version import __version__
 
@@ -148,9 +147,7 @@ def PastasDeprecationWarning(version: str, reason: str = "") -> Any:
                     f"{name} is deprecated and will not be available "
                     f"from Pastas version >={VERSION}. {reason}"
                 )
-                deprecated(message=msg, category=DeprecationWarning)(obj)(
-                    *args, **kwargs
-                )
+                warn(message=msg, category=DeprecationWarning)
             else:
                 msg = (
                     f"module has no attribute '{name}'",
@@ -199,7 +196,7 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
             f"The {name} argument is deprecated and will not be available"
             f" from Pastas version >={VERSION}. {reason}"
         )
-        deprecated(message=msg, category=DeprecationWarning)(lambda: None)()
+        warn(message=msg, category=DeprecationWarning)
     else:
         msg = (
             f"got an unexpected keyword argument {name}"

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -154,7 +154,7 @@ def PastasDeprecationWarning(
                 )
                 logger.warning(msg)
             elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
-                raise ModuleNotFoundError("no module named '%s'" % name)
+                raise AttributeError("module has no attribute '%s'" % name)
             else:
                 msg = (
                     f"{name} is deprecated and is not available since"

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -12,8 +12,8 @@ from typing import Any
 
 from packaging.version import parse as parse_version
 from pandas import Timestamp
-
 from pastas.version import __version__
+from typing_extensions import deprecated  # available in warnings from python 3.13
 
 try:
     from cachetools import cachedmethod
@@ -112,9 +112,7 @@ def model_tmin_tmax(function: Callable) -> Callable:
     return _model_tmin_tmax
 
 
-def PastasDeprecationWarning(
-    deprecate_version: str, remove_version: str, reason: str = ""
-) -> Any:
+def PastasDeprecationWarning(version: str, reason: str = "") -> Any:
     """Provide a warning or error when a Pastas class, method or function is deprecated.
 
     This decorator manages deprecation of classes, functions, or methods across Pastas versions.
@@ -146,22 +144,22 @@ def PastasDeprecationWarning(
         name = obj.__name__
 
         def _function(*args, **kwargs):
-            DEPRECATE_VERSION = parse_version(deprecate_version)
-            REMOVE_VERSION = parse_version(remove_version)
-            if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
+            VERSION = parse_version(version)
+            if CURRENT_PASTAS_VERSION < VERSION:
                 msg = (
                     f"{name} is deprecated and will not be available "
-                    f"from Pastas version >={DEPRECATE_VERSION}. {reason}"
+                    f"from Pastas version >={VERSION}. {reason}"
                 )
-                logger.warning(msg)
-            elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
-                raise AttributeError("module has no attribute '%s'" % name)
+                deprecated(message=msg, category=DeprecationWarning)(obj)(
+                    *args, **kwargs
+                )
             else:
                 msg = (
+                    f"module has no attribute '{name}'",
                     f"{name} is deprecated and is not available since"
-                    f" Pastas version {DEPRECATE_VERSION}. {reason}"
+                    f" Pastas version {VERSION}. {reason}",
                 )
-                raise DeprecationWarning(msg)
+                raise AttributeError(msg)
 
             return obj(*args, **kwargs)
 
@@ -170,12 +168,7 @@ def PastasDeprecationWarning(
     return wrapper
 
 
-def deprecate_args_or_kwargs(
-    name: str,
-    deprecate_version: str,
-    remove_version: str,
-    reason: str = "",
-):
+def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
     """Provide a warning or error when a function argument is deprecated.
 
     This function raises errors or warnings based on the current Pastas version and the
@@ -205,23 +198,20 @@ def deprecate_args_or_kwargs(
     TypeError
         If current version >= remove_version and the argument is used.
     """
-    DEPRECATE_VERSION = parse_version(deprecate_version)
-    REMOVE_VERSION = parse_version(remove_version)
-
-    if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
+    VERSION = parse_version(version)
+    if CURRENT_PASTAS_VERSION < VERSION:
         msg = (
             f"The {name} argument is deprecated and will not be available"
-            f" from Pastas version >={DEPRECATE_VERSION}. {reason}"
+            f" from Pastas version >={VERSION}. {reason}"
         )
-        logger.warning(msg)
-    elif CURRENT_PASTAS_VERSION >= REMOVE_VERSION:
-        raise TypeError("got an unexpected keyword argument '%s'" % name)
+        deprecated(message=msg, category=DeprecationWarning)(lambda: None)()
     else:
         msg = (
+            f"got an unexpected keyword argument {name}"
             f"The {name} argument is deprecated and is not available"
-            f" since Pastas version {DEPRECATE_VERSION}. {reason}"
+            f" since Pastas version {VERSION}. {reason}"
         )
-        raise DeprecationWarning(msg)
+        raise TypeError(msg)
 
 
 def njit(function: Callable | None = None, **kwargs) -> Callable:

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -10,6 +10,7 @@ from functools import wraps
 from logging import getLogger
 from typing import Any
 from warnings import warn
+
 from packaging.version import parse as parse_version
 from pandas import Timestamp
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -122,7 +122,7 @@ def PastasDeprecationWarning(
 
     - If current version < deprecate_version: logs a warning and allows execution to continue
     - If deprecate_version <= current version < remove_version: raises DeprecationWarning
-    - If current version >= remove_version: raises ModuleNotFoundError which indicates
+    - If current version >= remove_version: raises AttributeError which indicates
     that it can be removed from the codebase entirely
 
     Parameters
@@ -130,7 +130,8 @@ def PastasDeprecationWarning(
     deprecate_version: str
         The version in which the function or class begins raising a DeprecationWarning.
     remove_version: str
-        The version in which the function or class will be removed from Pastas and raise ModuleNotFoundError.
+        The version in which the function or class will be removed from the Pastas codebase
+        and raises an AttributeError.
     reason: str, optional
         The reason why the function or class is deprecated, or a message directing users
         to an alternative. Default is an empty string.

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -226,7 +226,7 @@ def deprecate_args_or_kwargs(
     else:
         msg = (
             f"The {name} argument is deprecated and is not available "
-            f"anymore since Pastas version {DEPRECATE_VERSION}. {reason}"
+            f"since Pastas version {DEPRECATE_VERSION}. {reason}"
         )
         raise DeprecationWarning(msg)
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -215,7 +215,7 @@ def deprecate_args_or_kwargs(
     if CURRENT_PASTAS_VERSION < DEPRECATE_VERSION:
         msg = (
             f"The {name} argument is deprecated and will not available"
-            f" anymore in Pastas version {DEPRECATE_VERSION}. {reason}"
+            f" from Pastas version >={DEPRECATE_VERSION}. {reason}"
         )
         if force_raise:
             raise DeprecationWarning(msg)

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -118,16 +118,13 @@ def PastasDeprecationWarning(version: str, reason: str = "") -> Any:
     This decorator manages deprecation of classes, functions, or methods across Pastas versions.
     The behavior depends on the current version:
 
-    - If current version < deprecate_version: logs a warning and allows execution to continue
-    - If deprecate_version <= current version < remove_version: raises DeprecationWarning
-    - If current version >= remove_version: raises AttributeError which indicates
+    - If current version < version: logs a warning and allows execution to continue
+    - If current version >= version: raises AttributeError which indicates
     that it can be removed from the codebase entirely
 
     Parameters
     ----------
-    deprecate_version: str
-        The version in which the function or class begins raising a DeprecationWarning.
-    remove_version: str
+    version: str
         The version in which the function or class will be removed from the Pastas codebase
         and raises an AttributeError.
     reason: str, optional
@@ -174,18 +171,15 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
     This function raises errors or warnings based on the current Pastas version and the
     deprecation timeline. The behavior is:
 
-    - If current version < deprecate_version: logs a warning
-    - If deprecate_version <= current version < remove_version: raises DeprecationWarning
-    - If current version >= remove_version: raises TypeError which indicates that it can be
+    - If current version < version: logs a warning
+    - If current version >= version: raises TypeError which indicates that it can be
     removed from the codebase entirely
 
     Parameters
     ----------
     name: str
         The name of the argument that is deprecated.
-    deprecate_version: str
-        The version in which the argument becomes deprecated.
-    remove_version: str
+    version: str
         The version in which the argument will be removed and TypeError will be raised.
     reason: str, optional
         The reason why the argument is deprecated, or a message directing users to
@@ -194,9 +188,9 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
     Raises
     ------
     DeprecationWarning
-        If between deprecate_version and remove_version and current version < deprecate_version.
+        If current version < version and the argument is used.
     TypeError
-        If current version >= remove_version and the argument is used.
+        If current version >= version and the argument is used.
     """
     VERSION = parse_version(version)
     if CURRENT_PASTAS_VERSION < VERSION:

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -12,8 +12,9 @@ from typing import Any
 
 from packaging.version import parse as parse_version
 from pandas import Timestamp
-from pastas.version import __version__
 from typing_extensions import deprecated  # available in warnings from python 3.13
+
+from pastas.version import __version__
 
 try:
     from cachetools import cachedmethod

--- a/pastas/forecast.py
+++ b/pastas/forecast.py
@@ -82,8 +82,7 @@ def _check_forecast_data(
         else:
             deprecate_args_or_kwargs(
                 name="forecasts",
-                deprecate_version="2.0.0",
-                remove_version="2.2.0",
+                version="2.0.0",
                 reason=(
                     "A list of DataFrames is deprecated. The forecast argument will"
                     " require a dictionary of DataFrames, with the appropriate keyword"

--- a/pastas/forecast.py
+++ b/pastas/forecast.py
@@ -82,7 +82,8 @@ def _check_forecast_data(
         else:
             deprecate_args_or_kwargs(
                 name="forecasts",
-                remove_version="2.0.0",
+                deprecate_version="2.0.0",
+                remove_version="2.2.0",
                 reason=(
                     "A list of DataFrames is deprecated. The forecast argument will"
                     " require a dictionary of DataFrames, with the appropriate keyword"

--- a/pastas/forecast.py
+++ b/pastas/forecast.py
@@ -89,7 +89,6 @@ def _check_forecast_data(
                     " require a dictionary of DataFrames, with the appropriate keyword"
                     " arguments of the stressmodel as keys of the dictionary instead."
                 ),
-                force_raise=False,
             )
         for fc in fc_data:
             # Convert Series to a 1-column DataFrame

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -162,18 +162,19 @@ class Model:
                     "noisemodel is desired. See this issue on GitHub for more "
                     "information: https://github.com/pastas/pastas/issues/735"
                 )
-                deprecate_args_or_kwargs(
-                    "noisemodel", "2.0.0", reason=msg, force_raise=True
-                )
             elif noisemodel is False:
                 msg = (
                     "The new default is that no noisemodel is added "
                     "anymore, so passing noisemodel=False is not needed anymore. To "
                     "fix this error, do not pass noisemodel=False to Model."
                 )
-                deprecate_args_or_kwargs(
-                    "noisemodel", "2.0.0", reason=msg, force_raise=True
-                )
+            deprecate_args_or_kwargs(
+                name="noisemodel",
+                deprecate_version="2.0.0",
+                remove_version="2.2.0",
+                reason=msg,
+                force_raise=True,
+            )
 
         # File Information
         self.file_info = self._get_file_info()
@@ -806,7 +807,13 @@ class Model:
                 "ml.del_noisemodel() before solving. See this issue on GitHub for "
                 "more information: https://github.com/pastas/pastas/issues/735"
             )
-            deprecate_args_or_kwargs("noise", "2.0.0", reason=msg, force_raise=True)
+            deprecate_args_or_kwargs(
+                name="noise",
+                deprecate_version="2.0.0",
+                remove_version="2.2.0",
+                reason=msg,
+                force_raise=True,
+            )
 
         # Set the settings
         self._settings["weights"] = weights
@@ -978,7 +985,6 @@ class Model:
                     "GitHub for more information: "
                     "https://github.com/pastas/pastas/issues/735"
                 )
-                deprecate_args_or_kwargs("noise", "2.0.0", reason=msg, force_raise=True)
             elif noise is False:
                 msg = (
                     "To solve without a noisemodel, remove the noisemodel "
@@ -986,7 +992,13 @@ class Model:
                     "solving. See this issue on GitHub for more information: "
                     "https://github.com/pastas/pastas/issues/735"
                 )
-                deprecate_args_or_kwargs("noise", "2.0.0", reason=msg, force_raise=True)
+            deprecate_args_or_kwargs(
+                name="noise",
+                deprecate_version="2.0.0",
+                remove_version="2.2.0",
+                reason=msg,
+                force_raise=True,
+            )
 
         if initialize:
             self.initialize(
@@ -1042,7 +1054,11 @@ class Model:
             self._generate_warnings_report()  # log warnings even if no report
 
     @property
-    @PastasDeprecationWarning(remove_version="2.0.0", reason="Use 'ml.solver' instead.")
+    @PastasDeprecationWarning(
+        deprecate_version="2.0.0",
+        remove_version="2.2.0",
+        reason="Use 'ml.solver' instead.",
+    )
     def fit(self):
         """Deprecated attribute, use ml.solver instead."""
         msg = (
@@ -2132,7 +2148,12 @@ class Model:
 
         if output is not None:
             msg = "Use 'corr=True' instead."
-            deprecate_args_or_kwargs("output", "2.0.0", reason=msg)
+            deprecate_args_or_kwargs(
+                name="output",
+                deprecate_version="2.0.0",
+                remove_version="2.2.0",
+                reason=msg,
+            )
             if isinstance(output, str) and output == "full":
                 corr = True
 

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -170,8 +170,7 @@ class Model:
                 )
             deprecate_args_or_kwargs(
                 name="noisemodel",
-                deprecate_version="1.5.0",
-                remove_version="2.0.0",
+                version="1.5.0",
                 reason=msg,
             )
 
@@ -808,8 +807,7 @@ class Model:
             )
             deprecate_args_or_kwargs(
                 name="noise",
-                deprecate_version="1.5.0",
-                remove_version="2.0.0",
+                version="1.5.0",
                 reason=msg,
             )
 
@@ -992,8 +990,7 @@ class Model:
                 )
             deprecate_args_or_kwargs(
                 name="noise",
-                deprecate_version="1.5.0",
-                remove_version="2.0.0",
+                version="1.5.0",
                 reason=msg,
             )
 
@@ -1052,8 +1049,7 @@ class Model:
 
     @property
     @PastasDeprecationWarning(
-        deprecate_version="2.0.0",
-        remove_version="2.2.0",
+        version="2.0.0",
         reason="Use 'ml.solver' instead.",
     )
     def fit(self):
@@ -2147,8 +2143,7 @@ class Model:
             msg = "Use 'corr=True' instead."
             deprecate_args_or_kwargs(
                 name="output",
-                deprecate_version="2.0.0",
-                remove_version="2.2.0",
+                version="2.0.0",
                 reason=msg,
             )
             if isinstance(output, str) and output == "full":

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -170,10 +170,9 @@ class Model:
                 )
             deprecate_args_or_kwargs(
                 name="noisemodel",
-                deprecate_version="2.0.0",
-                remove_version="2.2.0",
+                deprecate_version="1.5.0",
+                remove_version="2.0.0",
                 reason=msg,
-                force_raise=True,
             )
 
         # File Information
@@ -809,10 +808,9 @@ class Model:
             )
             deprecate_args_or_kwargs(
                 name="noise",
-                deprecate_version="2.0.0",
-                remove_version="2.2.0",
+                deprecate_version="1.5.0",
+                remove_version="2.0.0",
                 reason=msg,
-                force_raise=True,
             )
 
         # Set the settings
@@ -994,10 +992,9 @@ class Model:
                 )
             deprecate_args_or_kwargs(
                 name="noise",
-                deprecate_version="2.0.0",
-                remove_version="2.2.0",
+                deprecate_version="1.5.0",
+                remove_version="2.0.0",
                 reason=msg,
-                force_raise=True,
             )
 
         if initialize:

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -263,7 +263,9 @@ class ArNoiseModel(NoiseModelBase):
 
 
 @PastasDeprecationWarning(
-    remove_version="2.0.0", reason="Please use `ps.ArNoiseModel` instead."
+    deprecate_version="2.0.0",
+    remove_version="2.2.0",
+    reason="Please use `ps.ArNoiseModel` instead.",
 )
 def NoiseModel(*args, **kwargs) -> ArNoiseModel:
     n = ArNoiseModel(*args, **kwargs)
@@ -356,7 +358,9 @@ class ArmaNoiseModel(NoiseModelBase):
 
 
 @PastasDeprecationWarning(
-    remove_version="2.0.0", reason="Please use `ps.ArmaNoiseModel` instead."
+    deprecate_version="2.0.0",
+    remove_version="2.2.0",
+    reason="Please use `ps.ArmaNoiseModel` instead.",
 )
 def ArmaModel(*args, **kwargs) -> ArmaNoiseModel:
     n = ArmaNoiseModel(*args, **kwargs)

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -263,8 +263,7 @@ class ArNoiseModel(NoiseModelBase):
 
 
 @PastasDeprecationWarning(
-    deprecate_version="2.0.0",
-    remove_version="2.2.0",
+    version="2.0.0",
     reason="Please use `ps.ArNoiseModel` instead.",
 )
 def NoiseModel(*args, **kwargs) -> ArNoiseModel:
@@ -358,8 +357,7 @@ class ArmaNoiseModel(NoiseModelBase):
 
 
 @PastasDeprecationWarning(
-    deprecate_version="2.0.0",
-    remove_version="2.2.0",
+    version="2.0.0",
     reason="Please use `ps.ArmaNoiseModel` instead.",
 )
 def ArmaModel(*args, **kwargs) -> ArmaNoiseModel:

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -1086,8 +1086,7 @@ class Plotting:
         return axes
 
     @PastasDeprecationWarning(
-        deprecate_version="1.6.0",
-        remove_version="2.0.0",
+        version="1.6.0",
         reason=(
             "Quantifying contributions in one plot is ambiguous. "
             "Users are encouraged develop this themselves."

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -1086,7 +1086,8 @@ class Plotting:
         return axes
 
     @PastasDeprecationWarning(
-        remove_version="1.6.0",
+        deprecate_version="1.6.0",
+        remove_version="2.0.0",
         reason=(
             "Quantifying contributions in one plot is ambiguous. "
             "Users are encouraged develop this themselves."

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1540,8 +1540,7 @@ class DoubleExponential(RfuncBase):
 
 
 @PastasDeprecationWarning(
-    deprecate_version="2.0.0",
-    remove_version="2.2.0",
+    version="2.0.0",
     reason=(
         "Please use the pastas-plugins library if you want to keep using this "
         "response function (https://github.com/pastas/pastas/issues/475)."

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1540,7 +1540,8 @@ class DoubleExponential(RfuncBase):
 
 
 @PastasDeprecationWarning(
-    remove_version="2.0.0",
+    deprecate_version="2.0.0",
+    remove_version="2.2.0",
     reason=(
         "Please use the pastas-plugins library if you want to keep using this "
         "response function (https://github.com/pastas/pastas/issues/475)."

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -701,8 +701,7 @@ def kge(
 
 
 @PastasDeprecationWarning(
-    deprecate_version="2.0.0",
-    remove_version="2.2.0",
+    version="2.0.0",
     reason="""This function `kge_2012` will be deprecated in Pastas version 2.0. Please
     use `pastas.stats.kge(modified=True)` to get the same outcome.""",
 )

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -701,7 +701,8 @@ def kge(
 
 
 @PastasDeprecationWarning(
-    remove_version="2.0",
+    deprecate_version="2.0.0",
+    remove_version="2.2.0",
     reason="""This function `kge_2012` will be deprecated in Pastas version 2.0. Please
     use `pastas.stats.kge(modified=True)` to get the same outcome.""",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pandas >= 2.2.2, < 3.0",
     "scipy >= 1.13.0",
     "numba >= 0.60.0",
+    "typing_extensions >= 4.5.0",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "pandas >= 2.2.2, < 3.0",
     "scipy >= 1.13.0",
     "numba >= 0.60.0",
-    "typing_extensions >= 4.5.0",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -6,16 +6,20 @@ from pastas.decorators import PastasDeprecationWarning, deprecate_args_or_kwargs
 
 
 def test_class_deprecation() -> None:
-    # deprecate class in future version
-    @PastasDeprecationWarning(remove_version="999.0.0", reason="Boo!")
+    # class will be removed in future version - should log warning
+    @PastasDeprecationWarning(
+        deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
+    )
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-    Deprecated(1)
+    Deprecated(1)  # logs warning, continues execution
 
-    # class was deprecated in older version
-    @PastasDeprecationWarning(remove_version="1.0.0", reason="Boo!")
+    # class is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
+    @PastasDeprecationWarning(
+        deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+    )
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
@@ -23,61 +27,119 @@ def test_class_deprecation() -> None:
     with pytest.raises(DeprecationWarning):
         Deprecated(1)
 
-
-def test_classmethod_deprecation() -> None:
-    # deprecate class in future version
+    # class was already removed in past version - should raise ModuleNotFoundError
+    @PastasDeprecationWarning(
+        deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
+    )
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(remove_version="999.0.0", reason="Boo!")
+    with pytest.raises(ModuleNotFoundError):
+        Deprecated(1)
+
+
+def test_classmethod_deprecation() -> None:
+    # method will be removed in future version - should log warning
+    class Deprecated:
+        def __init__(self, a: Any) -> None:
+            self.a = a
+
+        @PastasDeprecationWarning(
+            deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
+        )
         def foo(self, b: Any) -> Any:
             return self.a + b
 
     d = Deprecated(1)
-    d.foo(2)  # warning
+    d.foo(2)  # logs warning, continues execution
 
-    # class was deprecated in older version
+    # method is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(remove_version="1.0.0", reason="Boo!")
+        @PastasDeprecationWarning(
+            deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+        )
         def foo(self, b: Any) -> Any:
             return self.a + b
 
     with pytest.raises(DeprecationWarning):
         d = Deprecated(1)
+        d.foo(2)
+
+    # method was already removed in past version - should raise ModuleNotFoundError
+    class Deprecated:
+        def __init__(self, a: Any) -> None:
+            self.a = a
+
+        @PastasDeprecationWarning(
+            deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
+        )
+        def foo(self, b: Any) -> Any:
+            return self.a + b
+
+    with pytest.raises(ModuleNotFoundError):
+        d = Deprecated(1)
         d.foo(2)  # raises error
 
 
 def test_function_deprecation() -> None:
-    # deprecate function in future version
-    @PastasDeprecationWarning(remove_version="999.0.0", reason="Boo!")
+    # function will be removed in future version - should log warning
+    @PastasDeprecationWarning(
+        deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
+    )
     def foo(a: Any) -> None:
         print(a)
 
-    foo(1)  # warning
+    foo(1)  # logs warning, continues execution
 
-    # function was deprecated in older version
-    @PastasDeprecationWarning(remove_version="1.0.0", reason="Boo!")
+    # function is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
+    @PastasDeprecationWarning(
+        deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+    )
     def foo(a: Any) -> None:
         print(a)
 
     with pytest.raises(DeprecationWarning):
+        foo(1)
+
+    # function was already removed in past version - should raise ModuleNotFoundError
+    @PastasDeprecationWarning(
+        deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
+    )
+    def foo(a: Any) -> None:
+        print(a)
+
+    with pytest.raises(ModuleNotFoundError):
         foo(1)  # raises error
 
 
 def test_deprecate_args_or_kwargs() -> None:
     # log warning for future deprecation
-    deprecate_args_or_kwargs("test", remove_version="999.0.0", reason="Boo!")
+    deprecate_args_or_kwargs(
+        "test", deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
+    )
 
     # force error even for future deprecation
     with pytest.raises(DeprecationWarning):
         deprecate_args_or_kwargs(
-            "test", remove_version="999.0.0", reason="Boo!", force_raise=True
+            "test",
+            deprecate_version="999.0.0",
+            remove_version="1000.0.0",
+            reason="Boo!",
+            force_raise=True,
         )
 
-    # raise error for past deprecation
+    # raise error when between deprecate and remove versions
     with pytest.raises(DeprecationWarning):
-        deprecate_args_or_kwargs("test", remove_version="1.0.0", reason="Boo!")
+        deprecate_args_or_kwargs(
+            "test", deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+        )
+
+    # raise TypeError when remove version has been reached
+    with pytest.raises(TypeError):
+        deprecate_args_or_kwargs(
+            "test", deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
+        )

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -18,16 +18,16 @@ def test_class_deprecation() -> None:
 
     # class is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
     @PastasDeprecationWarning(
-        deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+        deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
     )
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(DeprecationWarning, match="deprecated and is not available"):
         Deprecated(1)
 
-    # class was already removed in past version - should raise ModuleNotFoundError
+    # class was already removed in past version - should raise AttributeError
     @PastasDeprecationWarning(
         deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
     )
@@ -35,7 +35,7 @@ def test_class_deprecation() -> None:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(AttributeError, match="module has no attribute"):
         Deprecated(1)
 
 
@@ -60,16 +60,16 @@ def test_classmethod_deprecation() -> None:
             self.a = a
 
         @PastasDeprecationWarning(
-            deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+            deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
         )
         def foo(self, b: Any) -> Any:
             return self.a + b
 
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(DeprecationWarning, match="deprecated and is not available"):
         d = Deprecated(1)
         d.foo(2)
 
-    # method was already removed in past version - should raise ModuleNotFoundError
+    # method was already removed in past version - should raise AttributeError
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
@@ -80,7 +80,7 @@ def test_classmethod_deprecation() -> None:
         def foo(self, b: Any) -> Any:
             return self.a + b
 
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(AttributeError, match="module has no attribute"):
         d = Deprecated(1)
         d.foo(2)  # raises error
 
@@ -97,22 +97,22 @@ def test_function_deprecation() -> None:
 
     # function is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
     @PastasDeprecationWarning(
-        deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+        deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
     )
     def foo(a: Any) -> None:
         print(a)
 
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(DeprecationWarning, match="deprecated and is not available"):
         foo(1)
 
-    # function was already removed in past version - should raise ModuleNotFoundError
+    # function was already removed in past version - should raise AttributeError
     @PastasDeprecationWarning(
         deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
     )
     def foo(a: Any) -> None:
         print(a)
 
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(AttributeError, match="module has no attribute"):
         foo(1)  # raises error
 
 
@@ -123,7 +123,7 @@ def test_deprecate_args_or_kwargs() -> None:
     )
 
     # force error even for future deprecation
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(DeprecationWarning, match="will not be available"):
         deprecate_args_or_kwargs(
             "test",
             deprecate_version="999.0.0",
@@ -133,13 +133,13 @@ def test_deprecate_args_or_kwargs() -> None:
         )
 
     # raise error when between deprecate and remove versions
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(DeprecationWarning, match="is not available"):
         deprecate_args_or_kwargs(
-            "test", deprecate_version="1.0.0", remove_version="2.0.0", reason="Boo!"
+            "test", deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
         )
 
     # raise TypeError when remove version has been reached
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
         deprecate_args_or_kwargs(
             "test", deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
         )

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -7,30 +7,15 @@ from pastas.decorators import PastasDeprecationWarning, deprecate_args_or_kwargs
 
 def test_class_deprecation() -> None:
     # class will be removed in future version - should log warning
-    @PastasDeprecationWarning(
-        deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
-    )
+    @PastasDeprecationWarning(version="999.0.0", reason="Boo!")
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
     Deprecated(1)  # logs warning, continues execution
 
-    # class is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
-    @PastasDeprecationWarning(
-        deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
-    )
-    class Deprecated:
-        def __init__(self, a: Any) -> None:
-            self.a = a
-
-    with pytest.raises(DeprecationWarning, match="deprecated and is not available"):
-        Deprecated(1)
-
-    # class was already removed in past version - should raise AttributeError
-    @PastasDeprecationWarning(
-        deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
-    )
+    # class was already removed (version <= current) - should raise AttributeError
+    @PastasDeprecationWarning(version="0.1.0", reason="Boo!")
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
@@ -45,38 +30,19 @@ def test_classmethod_deprecation() -> None:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(
-            deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
-        )
+        @PastasDeprecationWarning(version="999.0.0", reason="Boo!")
         def foo(self, b: Any) -> Any:
             return self.a + b
 
     d = Deprecated(1)
     d.foo(2)  # logs warning, continues execution
 
-    # method is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
+    # method was already removed (version <= current) - should raise AttributeError
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(
-            deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
-        )
-        def foo(self, b: Any) -> Any:
-            return self.a + b
-
-    with pytest.raises(DeprecationWarning, match="deprecated and is not available"):
-        d = Deprecated(1)
-        d.foo(2)
-
-    # method was already removed in past version - should raise AttributeError
-    class Deprecated:
-        def __init__(self, a: Any) -> None:
-            self.a = a
-
-        @PastasDeprecationWarning(
-            deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
-        )
+        @PastasDeprecationWarning(version="0.1.0", reason="Boo!")
         def foo(self, b: Any) -> Any:
             return self.a + b
 
@@ -87,28 +53,14 @@ def test_classmethod_deprecation() -> None:
 
 def test_function_deprecation() -> None:
     # function will be removed in future version - should log warning
-    @PastasDeprecationWarning(
-        deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
-    )
+    @PastasDeprecationWarning(version="999.0.0", reason="Boo!")
     def foo(a: Any) -> None:
         print(a)
 
     foo(1)  # logs warning, continues execution
 
-    # function is currently deprecated (between deprecate and remove versions) - should raise DeprecationWarning
-    @PastasDeprecationWarning(
-        deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
-    )
-    def foo(a: Any) -> None:
-        print(a)
-
-    with pytest.raises(DeprecationWarning, match="deprecated and is not available"):
-        foo(1)
-
-    # function was already removed in past version - should raise AttributeError
-    @PastasDeprecationWarning(
-        deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
-    )
+    # function was already removed (version <= current) - should raise AttributeError
+    @PastasDeprecationWarning(version="0.1.0", reason="Boo!")
     def foo(a: Any) -> None:
         print(a)
 
@@ -118,18 +70,8 @@ def test_function_deprecation() -> None:
 
 def test_deprecate_args_or_kwargs() -> None:
     # log warning for future deprecation
-    deprecate_args_or_kwargs(
-        "test", deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
-    )
+    deprecate_args_or_kwargs("test", version="999.0.0", reason="Boo!")
 
-    # raise error when between deprecate and remove versions
-    with pytest.raises(DeprecationWarning, match="is not available"):
-        deprecate_args_or_kwargs(
-            "test", deprecate_version="1.0.0", remove_version="10.0.0", reason="Boo!"
-        )
-
-    # raise TypeError when remove version has been reached
+    # raise TypeError when version has been reached
     with pytest.raises(TypeError, match="got an unexpected keyword argument"):
-        deprecate_args_or_kwargs(
-            "test", deprecate_version="0.1.0", remove_version="1.0.0", reason="Boo!"
-        )
+        deprecate_args_or_kwargs("test", version="0.1.0", reason="Boo!")

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -122,16 +122,6 @@ def test_deprecate_args_or_kwargs() -> None:
         "test", deprecate_version="999.0.0", remove_version="1000.0.0", reason="Boo!"
     )
 
-    # force error even for future deprecation
-    with pytest.raises(DeprecationWarning, match="will not be available"):
-        deprecate_args_or_kwargs(
-            "test",
-            deprecate_version="999.0.0",
-            remove_version="1000.0.0",
-            reason="Boo!",
-            force_raise=True,
-        )
-
     # raise error when between deprecate and remove versions
     with pytest.raises(DeprecationWarning, match="is not available"):
         deprecate_args_or_kwargs(

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -4,74 +4,81 @@ import pytest
 
 from pastas.decorators import PastasDeprecationWarning, deprecate_args_or_kwargs
 
+msg = "Boo!"
+
 
 def test_class_deprecation() -> None:
-    # class will be removed in future version - should log warning
-    @PastasDeprecationWarning(version="999.0.0", reason="Boo!")
+    # class will be removed in future version - should show a DeprecationWarning
+    @PastasDeprecationWarning(version="999.0.0", reason=msg)
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-    Deprecated(1)  # logs warning, continues execution
+    with pytest.warns(DeprecationWarning, match=msg):
+        Deprecated(1)  # logs warning, continues execution
 
     # class was already removed (version <= current) - should raise AttributeError
-    @PastasDeprecationWarning(version="0.1.0", reason="Boo!")
+    @PastasDeprecationWarning(version="0.1.0", reason=msg)
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-    with pytest.raises(AttributeError, match="module has no attribute"):
+    with pytest.raises(AttributeError, match=msg):
         Deprecated(1)
 
 
 def test_classmethod_deprecation() -> None:
-    # method will be removed in future version - should log warning
+    # method will be removed in future version - should show a DeprecationWarning
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(version="999.0.0", reason="Boo!")
+        @PastasDeprecationWarning(version="999.0.0", reason=msg)
         def foo(self, b: Any) -> Any:
             return self.a + b
 
-    d = Deprecated(1)
-    d.foo(2)  # logs warning, continues execution
+    with pytest.warns(DeprecationWarning, match=msg):
+        d = Deprecated(1)
+        d.foo(2)  # shows warning, continues execution
 
     # method was already removed (version <= current) - should raise AttributeError
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(version="0.1.0", reason="Boo!")
+        @PastasDeprecationWarning(version="0.1.0", reason=msg)
         def foo(self, b: Any) -> Any:
             return self.a + b
 
-    with pytest.raises(AttributeError, match="module has no attribute"):
+    with pytest.raises(AttributeError, match=msg):
         d = Deprecated(1)
         d.foo(2)  # raises error
 
 
 def test_function_deprecation() -> None:
-    # function will be removed in future version - should log warning
-    @PastasDeprecationWarning(version="999.0.0", reason="Boo!")
+    # function will be removed in future version - should show a DeprecationWarning
+    @PastasDeprecationWarning(version="999.0.0", reason=msg)
     def foo(a: Any) -> None:
         print(a)
 
-    foo(1)  # logs warning, continues execution
+    with pytest.warns(DeprecationWarning, match=msg):
+        foo(1)  # shows warning, continues execution
 
     # function was already removed (version <= current) - should raise AttributeError
-    @PastasDeprecationWarning(version="0.1.0", reason="Boo!")
+    @PastasDeprecationWarning(version="0.1.0", reason=msg)
     def foo(a: Any) -> None:
         print(a)
 
-    with pytest.raises(AttributeError, match="module has no attribute"):
+    with pytest.raises(AttributeError, match=msg):
         foo(1)  # raises error
 
 
 def test_deprecate_args_or_kwargs() -> None:
     # log warning for future deprecation
-    deprecate_args_or_kwargs("test", version="999.0.0", reason="Boo!")
+    deprecate_args_or_kwargs(
+        "test", version="999.0.0", reason=msg
+    )  # shows warning, continues execution
 
     # raise TypeError when version has been reached
-    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
-        deprecate_args_or_kwargs("test", version="0.1.0", reason="Boo!")
+    with pytest.raises(TypeError, match=msg):
+        deprecate_args_or_kwargs("test", version="0.1.0", reason=msg)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -64,7 +64,7 @@ def test_stresses(ml_noisemodel: Model) -> None:
 
 
 def test_contributions_pie(ml_noisemodel: Model) -> None:
-    with pytest.raises(DeprecationWarning):
+    with pytest.raises(AttributeError):
         _ = ml_noisemodel.plots.contributions_pie()
         plt.close()
 


### PR DESCRIPTION
### Changes
* Refactored `PastasDeprecationWarning` to use a `version` argument (instead of `remove_version`), clarified its behavior: logs a warning if the current version is less than the specified version, and raises `AttributeError` if the current version is greater or equal, signaling that the feature can, but should not per se, be removed.
* Refactored `deprecate_args_or_kwargs` to use a `version` argument (instead of `remove_version` and `force_raise`), clarified its behavior: logs a warning if the current version is less than the specified version, and raises `TypeError` if the current version is greater or equal. Improved documentation and error messages for clarity.
* Replaced usage of `logger.warning` with the standard library `warnings.warn` for deprecation warnings to better align with Python best practices as requested by @rubencalje.