### PR TITLE
Switch to tox-uv for faster tests (on GitHub Actions)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/test_benchmark_notebooks.yml
+++ b/.github/workflows/test_benchmark_notebooks.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         include:
           - name: Test suite for benchmark Notebooks
-            python: "3.11"
             toxenv: notebooks
     env:
       # Color Output
@@ -34,10 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up uv
+      - name: Set up uv with Python
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ matrix.python }}
+          python-version: "3.11"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/test_benchmark_notebooks.yml
+++ b/.github/workflows/test_benchmark_notebooks.yml
@@ -34,21 +34,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
-          check-latest: true
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
+        run: uv pip install tox-uv
 
       - name: Setup tox environment
-        run: tox -e ${{ matrix.toxenv }} --notest
+        run: uv run tox -e ${{ matrix.toxenv }} --notest
 
       - name: Test
-        run: tox -e ${{ matrix.toxenv }} --skip-pkg-install
+        run: uv run tox -e ${{ matrix.toxenv }} --skip-pkg-install

--- a/.github/workflows/test_benchmark_notebooks.yml
+++ b/.github/workflows/test_benchmark_notebooks.yml
@@ -32,10 +32,10 @@ jobs:
       # Pytest
       PYTEST_ADDOPTS: "--color=yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           check-latest: true

--- a/.github/workflows/test_benchmark_notebooks.yml
+++ b/.github/workflows/test_benchmark_notebooks.yml
@@ -41,7 +41,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install tox-uv
+        run: |
+          uv venv
+          uv pip install tox-uv
 
       - name: Setup tox environment
         run: uv run tox -e ${{ matrix.toxenv }} --notest

--- a/.github/workflows/test_format_lint.yml
+++ b/.github/workflows/test_format_lint.yml
@@ -30,10 +30,10 @@ jobs:
       # Pytest
       PYTEST_ADDOPTS: "--color=yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           check-latest: true

--- a/.github/workflows/test_format_lint.yml
+++ b/.github/workflows/test_format_lint.yml
@@ -32,22 +32,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
-          check-latest: true
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
+        run: uv pip install tox-uv
 
       - name: Setup tox environment
-        run: tox -e ${{ matrix.toxenv }} --notest
+        run: uv run tox -e ${{ matrix.toxenv }} --notest
 
       - name: Test
-        run: tox -e ${{ matrix.toxenv }} --skip-pkg-install
+        run: uv run tox -e ${{ matrix.toxenv }} --skip-pkg-install
 

--- a/.github/workflows/test_format_lint.yml
+++ b/.github/workflows/test_format_lint.yml
@@ -16,10 +16,8 @@ jobs:
       matrix:
         include:
           - name: Formatting and linting with ruff
-            python: "3.11"
             toxenv: ruff
-          - name: Formatting and linting with ruff (Preview Mode)
-            python: "3.11"
+          - name: Formatting and linting with ruff in preview mode
             toxenv: ruff_preview
     env:
       # Color Output
@@ -35,7 +33,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ matrix.python }}
+          python-version: "3.11"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/test_format_lint.yml
+++ b/.github/workflows/test_format_lint.yml
@@ -39,7 +39,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install tox-uv
+        run: |
+          uv venv
+          uv pip install tox-uv
 
       - name: Setup tox environment
         run: uv run tox -e ${{ matrix.toxenv }} --notest

--- a/.github/workflows/test_spelling.yml
+++ b/.github/workflows/test_spelling.yml
@@ -11,21 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ matrix.python }}
-          check-latest: true
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
+          python-version: "3.11"
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
+        run: uv pip install tox-uv
 
       - name: Setup tox environment
-        run: tox -e codespell --notest
+        run: uv run tox -e codespell --notest
 
       - name: Test
-        run: tox -e codespell --skip-pkg-install
+        run: uv run tox -e codespell --skip-pkg-install

--- a/.github/workflows/test_spelling.yml
+++ b/.github/workflows/test_spelling.yml
@@ -18,7 +18,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install tox-uv
+        run: |
+          uv venv
+          uv pip install tox-uv
 
       - name: Setup tox environment
         run: uv run tox -e codespell --notest

--- a/.github/workflows/test_spelling.yml
+++ b/.github/workflows/test_spelling.yml
@@ -9,10 +9,10 @@ jobs:
   code-spell-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           check-latest: true

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -61,24 +61,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
-          check-latest: true
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
+        run: uv pip install tox-uv
 
       - name: Setup tox environment
-        run: tox -e ${{ matrix.toxenv }} --notest
+        run: uv run tox -e ${{ matrix.toxenv }} --notest
 
       - name: Test
-        run: tox -e ${{ matrix.toxenv }} --skip-pkg-install
+        run: uv run tox -e ${{ matrix.toxenv }} --skip-pkg-install
 
       - name: Run codacy-coverage-reporter
         if: ${{ matrix.toxenv == 'all' && github.repository == 'pastas/pastas' && success() }}

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -68,7 +68,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install tox-uv
+        run: |
+          uv venv
+          uv pip install tox-uv
 
       - name: Setup tox environment
         run: uv run tox -e ${{ matrix.toxenv }} --notest

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up uv
+      - name: Set up uv with Python ${{ matrix.python }}
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -59,10 +59,10 @@ jobs:
       # Pytest
       PYTEST_ADDOPTS: "--color=yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           check-latest: true

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -43,7 +43,7 @@ jobs:
             toxenv: py313
             experimental: false
           - name: Test suite with py314-ubuntu
-            python: "3.14-dev"
+            python: "3.14"
             toxenv: py314
             experimental: true
           - name: Test suite for all unit tests including Notebooks

--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ rtd = [
     "myst_nb",
     "sphinx-autoapi",
 ]
-dev = ["tox", "pre-commit", "pastas[ruffing,codespelling,ci,rtd]"]
+dev = ["tox-uv", "pre-commit", "pastas[ruffing,codespelling,ci,rtd]"]
 
 [dependency-groups]
 dev = ["pastas[dev]"]
@@ -103,7 +103,8 @@ ignore-regex = "[A-Za-z0-9+/]{100,}"                           # base64-encoded 
 ignore-words-list = ["delt", "te", "theses", "Bilt", "Strack"]
 
 [tool.tox]
-requires = ["tox>=4"]
+requires = ["tox-uv>=1.0"]
+package = "wheel"
 env_list = ["py310", "py311", "py312", "py313", "py314", "ruff", "notebooks"]
 
 [tool.tox.env_run_base]
@@ -170,4 +171,3 @@ commands = [
 description = "run spelling checks"
 extras = ["codespelling"]
 commands = [["codespell"]]
-


### PR DESCRIPTION
### Summary
Migrate the entire testing infrastructure to use `uv` and `tox-uv` for faster, more efficient dependency management and test execution.

### Changes

#### Configuration
- **pyproject.toml**: Updated `[tool.tox]` to require `tox-uv>=1.0` instead of `tox>=4`
- **pyproject.toml**: Changed `dev` dependency from `tox` to `tox-uv`

#### GitHub Workflows
Updated all CI workflows to use `astral-sh/setup-uv` for unified Python and uv installation:
- **test_unit_pytest.yml**: Replaced pip/tox with uv/tox-uv for unit tests across Python 3.10-3.14
- **test_format_lint.yml**: Updated to use uv/tox-uv for ruff linting and formatting checks
- **test_benchmark_notebooks.yml**: Migrated to uv/tox-uv for notebook testing
- **test_spelling.yml**: Updated to use uv/tox-uv for codespell checks

### Benefits
- **Faster dependency resolution**: uv is significantly faster than pip
- **Improved caching**: `astral-sh/setup-uv` provides better caching for both uv and packages
- **Cleaner workflow syntax**: Consolidated Python setup into single `setup-uv` action
- **Better compatibility**: `tox-uv` manages virtual environments more efficiently
