### PR TITLE
Better error message if nans simulated values

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -532,8 +532,8 @@ class Model:
 
         if sim.hasnans:
             msg = (
-                f"Simulation contains with parameters {p} contains "
-                "NaN-values. Check the parameters and/or if time "
+                f"Simulation with parameters {p} contains NaN"
+                "-values. Check the parameters and/or if the time "
                 "series settings are provided for each stress model "
                 "(e.g. `ps.StressModel(stress, settings='prec')`!"
             )

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -532,8 +532,9 @@ class Model:
 
         if sim.hasnans:
             msg = (
-                "Simulation contains NaN-values. Check if time series settings "
-                "are provided for each stress model "
+                f"Simulation contains with parameters {p} contains "
+                "NaN-values. Check the parameters and/or if time "
+                "series settings are provided for each stress model "
                 "(e.g. `ps.StressModel(stress, settings='prec')`!"
             )
             logger.error(msg)


### PR DESCRIPTION
# Short description
Running into some issues where there are nans in the simulated values due to the chosen parameter combinations. This PR makes sure that it is properly logged, including the parameter values.