### PR TITLE
Allow HTTPError in dataset tests

### DIFF
--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -12,14 +12,23 @@ Load a single dataset from the "collenteur_2021" subfolder::
 """
 
 from functools import lru_cache
+from typing import Literal
 
 from pandas import DataFrame, read_csv
 
 GITHUB_URL = "https://api.github.com/repos/pastas/pastas-data/contents/"
+DATASET_NAMES = Literal[
+    "collenteur_2019",
+    "collenteur_2021",
+    "collenteur_2023",
+    "collenteur_2024",
+    "spek_2017",
+    "vonk_2024",
+]
 
 
 @lru_cache
-def load_dataset(name: str) -> DataFrame | dict[str, DataFrame]:
+def load_dataset(name: DATASET_NAMES) -> DataFrame | dict[str, DataFrame]:
     """Load csv-files from a subfolder in the pastas dataset repository on GitHub.
 
     Parameters
@@ -97,7 +106,7 @@ def load_dataset(name: str) -> DataFrame | dict[str, DataFrame]:
 
 
 @lru_cache
-def list_datasets(silent: bool = True) -> list[str]:
+def list_datasets(silent: bool = True) -> list[DATASET_NAMES]:
     """Print a list of available datasets in the pastas-data repository on GitHub.
 
     Returns

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -11,8 +11,9 @@ Load a single dataset from the "collenteur_2021" subfolder::
 
 """
 
+import logging
 from functools import lru_cache
-from typing import Literal
+from typing import Literal, get_args
 
 from pandas import DataFrame, read_csv
 
@@ -25,6 +26,8 @@ DATASET_NAMES = Literal[
     "spek_2017",
     "vonk_2024",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache
@@ -71,6 +74,12 @@ def load_dataset(name: DATASET_NAMES) -> DataFrame | dict[str, DataFrame]:
         )
     from requests.exceptions import HTTPError
 
+    if name not in get_args(DATASET_NAMES):
+        logger.error(
+            f"Possibly invalid dataset name: {name}. Use "
+            "ps.list_datasets() to get a list of available datasets."
+        )
+
     # Get the folder from the pastas-data repository
     r = requests.get(f"{GITHUB_URL}/{name}/")
 
@@ -106,7 +115,7 @@ def load_dataset(name: DATASET_NAMES) -> DataFrame | dict[str, DataFrame]:
 
 
 @lru_cache
-def list_datasets(silent: bool = True) -> list[DATASET_NAMES]:
+def list_datasets(silent: bool = True) -> list[str]:
     """Print a list of available datasets in the pastas-data repository on GitHub.
 
     Returns

--- a/pastas/dataset.py
+++ b/pastas/dataset.py
@@ -75,7 +75,7 @@ def load_dataset(name: DATASET_NAMES) -> DataFrame | dict[str, DataFrame]:
     from requests.exceptions import HTTPError
 
     if name not in get_args(DATASET_NAMES):
-        logger.error(
+        logger.warning(
             f"Possibly invalid dataset name: {name}. Use "
             "ps.list_datasets() to get a list of available datasets."
         )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,16 +1,21 @@
+from typing import get_args
+
 import pytest
 from pandas import DataFrame
-from requests.exceptions import HTTPError
 
 from pastas.dataset import DATASET_NAMES, list_datasets, load_dataset
+
+requests = pytest.importorskip("requests")
 
 
 def test_load_multiple_csv() -> None:
     # Test loading multiple csv files
     try:
         dataset = load_dataset("collenteur_2023")
-    except HTTPError as e:
-        pytest.skip(f"HTTPError occurred: {e}")
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 429:
+            pytest.skip(f"Rate limit exceeded: {e}")
+        raise
     assert isinstance(dataset, dict)
     assert len(dataset) > 1
     for _, value in dataset.items():
@@ -27,10 +32,12 @@ def test_list_datasets() -> None:
     # Test listing available datasets
     try:
         datasets_list = list_datasets(silent=False)
-    except HTTPError as e:
-        pytest.skip(f"HTTPError occurred: {e}")
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 429:
+            pytest.skip(f"Rate limit exceeded: {e}")
+        raise
     # Add assertions here to verify the output of the function
     # For example, you can check if the output contains certain dataset names
     assert isinstance(datasets_list, list)
     assert all(isinstance(name, str) for name in datasets_list)
-    assert set(DATASET_NAMES.__args__).issubset(set(datasets_list))
+    assert set(get_args(DATASET_NAMES)).issubset(set(datasets_list))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,15 +1,19 @@
 import pytest
 from pandas import DataFrame
+from requests.exceptions import HTTPError
 
-from pastas.dataset import list_datasets, load_dataset
+from pastas.dataset import DATASET_NAMES, list_datasets, load_dataset
 
 
 def test_load_multiple_csv() -> None:
     # Test loading multiple csv files
-    dataset = load_dataset("collenteur_2023")
+    try:
+        dataset = load_dataset("collenteur_2023")
+    except HTTPError as e:
+        pytest.skip(f"HTTPError occurred: {e}")
     assert isinstance(dataset, dict)
     assert len(dataset) > 1
-    for key, value in dataset.items():
+    for _, value in dataset.items():
         assert isinstance(value, DataFrame)
 
 
@@ -21,7 +25,12 @@ def test_invalid_folder_name() -> None:
 
 def test_list_datasets() -> None:
     # Test listing available datasets
-    list_datasets(silent=False)
+    try:
+        datasets_list = list_datasets(silent=False)
+    except HTTPError as e:
+        pytest.skip(f"HTTPError occurred: {e}")
     # Add assertions here to verify the output of the function
     # For example, you can check if the output contains certain dataset names
-    # assert "collenteur_2021" in list_datasets()
+    assert isinstance(datasets_list, list)
+    assert all(isinstance(name, str) for name in datasets_list)
+    assert set(datasets_list).issubset(set(DATASET_NAMES.__args__))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -33,4 +33,4 @@ def test_list_datasets() -> None:
     # For example, you can check if the output contains certain dataset names
     assert isinstance(datasets_list, list)
     assert all(isinstance(name, str) for name in datasets_list)
-    assert set(datasets_list).issubset(set(DATASET_NAMES.__args__))
+    assert set(DATASET_NAMES.__args__).issubset(set(datasets_list))


### PR DESCRIPTION
# Short description
Dataset tests are frequently throwing rate limit errors. This is happening because we are using GitHub as a dataset, and hitting their API limits is common, expected behavior under these circumstances. Update the tests to handle and allow this behavior rather than failing the build/test suite.

# Checklist before PR can be merged:
- [x] closes issue #1142 
