### PR TITLE
Add solve strategies to Model.solve

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1041,19 +1041,22 @@ class Model:
                     raise ValueError(msg)
                 # copy the existing parameters, so we can set initial and vary back later
                 parameters = self.parameters.copy()
+                noise_parameters = parameters.index[
+                    parameters["name"] == self.noisemodel.name
+                ]
                 # fit model without noisemodel first
-                self.set_parameter("noise_alpha", vary=False)
+                self._parameters.loc[noise_parameters, "vary"] = False
                 success_previous, optimal, stderr = self.solver.solve(
                     noise=False, weights=weights, **kwargs
                 )
                 nfev = self.solver.nfev
                 self._parameters.initial = optimal
             if strategy == "deterministic_then_noise_only":
-                # fit only noise_alpha in a seperate solve-iteration
+                # fit only noisemodel parameters in a separate solve iteration
                 self._parameters.vary = False
-                self.set_parameter(
-                    "noise_alpha", vary=parameters.at["noise_alpha", "vary"]
-                )
+                self._parameters.loc[noise_parameters, "vary"] = parameters.loc[
+                    noise_parameters, "vary"
+                ]
                 success_iteration2, optimal, stderr = self.solver.solve(
                     noise=True, weights=weights, **kwargs
                 )
@@ -1064,9 +1067,9 @@ class Model:
                 self._parameters.vary = parameters["vary"]
                 kwargs["max_nfev"] = 1  # only calculate the jacobian once more
             elif strategy == "deterministic_then_full":
-                self.set_parameter(
-                    "noise_alpha", vary=parameters.at["noise_alpha", "vary"]
-                )
+                self._parameters.loc[noise_parameters, "vary"] = parameters.loc[
+                    noise_parameters, "vary"
+                ]
             else:
                 msg = f"Strategy '{strategy}' is not recognized. Available strategies are 'deterministic_then_noise_only' and 'deterministic_then_full'."
                 logger.error(msg)

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -892,6 +892,7 @@ class Model:
         fit_constant: bool = True,
         freq_obs: str | None = None,
         initialize: bool = True,
+        strategy: str | None = None,
         **kwargs,
     ) -> None:
         """Method to solve the time series model.
@@ -955,6 +956,13 @@ class Model:
             model is not initialized before solving. Note that the latter is an
             advanced option since some model settings can be missing. Default
             is True.
+        strategy: str, optional
+            Optional strategy for solving the model. Available strategies are
+            "deterministic_then_noise_only" (fit all deterministic parameters first,
+            then fit only the noise parameter) and "deterministic_then_full"
+            (fit deterministic parameters first and then continue with the
+            regular solve including noise). Strategies require a noisemodel to
+            be present in the model.
         **kwargs: dict, optional
             All keyword arguments will be passed onto minimization method from the
             solver. It depends on the solver used which arguments can be used.
@@ -1025,10 +1033,55 @@ class Model:
             solver = LeastSquares()
             self.add_solver(solver=solver)
 
+        if strategy is not None:
+            if strategy in ["deterministic_then_noise_only", "deterministic_then_full"]:
+                if self.noisemodel is None:
+                    msg = f"Strategy '{strategy}' cannot be used if no noisemodel is present in the model."
+                    logger.error(msg)
+                    raise ValueError(msg)
+                # copy the existing parameters, so we can set initial and vary back later
+                parameters = self.parameters.copy()
+                # fit model without noisemodel first
+                self.set_parameter("noise_alpha", vary=False)
+                success_previous, optimal, stderr = self.solver.solve(
+                    noise=False, weights=weights, **kwargs
+                )
+                nfev = self.solver.nfev
+                self._parameters.initial = optimal
+            if strategy == "deterministic_then_noise_only":
+                # fit only noise_alpha in a seperate solve-iteration
+                self._parameters.vary = False
+                self.set_parameter(
+                    "noise_alpha", vary=parameters.at["noise_alpha", "vary"]
+                )
+                success_iteration2, optimal, stderr = self.solver.solve(
+                    noise=True, weights=weights, **kwargs
+                )
+                success_previous = success_previous and success_iteration2
+                nfev = nfev + self.solver.nfev
+                self._parameters.initial = optimal
+                # then calculate the jacobian once more with all parameters active that were active to begin with
+                self._parameters.vary = parameters["vary"]
+                kwargs["max_nfev"] = 1  # only calculate the jacobian once more
+            elif strategy == "deterministic_then_full":
+                self.set_parameter(
+                    "noise_alpha", vary=parameters.at["noise_alpha", "vary"]
+                )
+            else:
+                msg = f"Strategy '{strategy}' is not recognized. Available strategies are 'deterministic_then_noise_only' and 'deterministic_then_full'."
+                logger.error(msg)
+                raise ValueError(msg)
+
         # Solve model
         success, optimal, stderr = self.solver.solve(
             noise=self._settings["noise"], weights=weights, **kwargs
         )
+        if strategy in ["deterministic_then_noise_only", "deterministic_then_full"]:
+            # set the initial values back to their original values
+            self._parameters.initial = parameters["initial"]
+            # and finally we set the nfev to the total of the three iterations
+            self.solver.nfev = nfev + self.solver.nfev
+            success = success and success_previous
         if not success:
             logger.warning("Model parameters could not be estimated well.")
 

--- a/pastas/solver.py
+++ b/pastas/solver.py
@@ -119,7 +119,6 @@ class BaseSolver:
         # Get the residuals or the noise
         if noise:
             rv = self.ml.noise(p) * self.ml.noise_weights(p)
-
         else:
             rv = self.ml.residuals(p)
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -26,6 +26,19 @@ def test_no_noise(ml_recharge: ps.Model) -> None:
     ml_recharge.solve()
 
 
+@pytest.mark.parametrize(
+    "strategy",
+    ["deterministic_then_noise_only", "deterministic_then_full"],
+)
+def test_solve_strategies_with_noisemodel(
+    ml_noisemodel: ps.Model, strategy: str
+) -> None:
+    ml_noisemodel.solve(strategy=strategy, report=False)
+    assert ml_noisemodel.solver.nfev is not None
+    assert ml_noisemodel.solver.nfev > 0
+    assert ml_noisemodel.parameters["optimal"].notna().all()
+
+
 # Tests for confidence intervals and prediction intervals
 def test_pred_interval(ml_recharge: ps.Model) -> None:
     ml_recharge.solve(solver=ps.LeastSquares())

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -39,6 +39,24 @@ def test_solve_strategies_with_noisemodel(
     assert ml_noisemodel.parameters["optimal"].notna().all()
 
 
+@pytest.mark.parametrize(
+    "strategy",
+    ["deterministic_then_noise_only", "deterministic_then_full"],
+)
+def test_solve_strategies_with_arma_noisemodel(
+    ml_recharge: ps.Model, strategy: str
+) -> None:
+    ml_recharge.add_noisemodel(ps.ArmaNoiseModel())
+    ml_recharge.solve(strategy=strategy, report=False)
+    assert ml_recharge.solver.nfev is not None
+    assert ml_recharge.solver.nfev > 0
+    assert (
+        ml_recharge.parameters.loc[["noise_alpha", "noise_beta"], "optimal"]
+        .notna()
+        .all()
+    )
+
+
 # Tests for confidence intervals and prediction intervals
 def test_pred_interval(ml_recharge: ps.Model) -> None:
     ml_recharge.solve(solver=ps.LeastSquares())


### PR DESCRIPTION
Introduce an optional strategy parameter to `Model.solve` to support two-step solving workflows: 

- "deterministic_then_noise_only"
- "deterministic_then_full".

Both require a noisemodel and temporarily adjust parameters to first fit deterministic components, then handle noise (either only `noise_alpha`/`noise_beta`, or continue to a full solve). The implementation copies and restores parameter states, adjusts which parameters vary, and accumulates nfev across iterations. Added validation and error messages for missing or unknown strategies. Also removed an extra blank line in BaseSolver and added tests covering the new strategies.

# Short description
Add a short description describing the pull request here.

# Checklist before PR can be merged:
- [ ] closes issue #xxxx
- [ ] is documented
- [ ] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [ ] type hints
- [ ] tests added or expanded
- [ ] remove output for all notebooks with changes
- [ ] example notebook (for new features)