### PR TITLE
add pause to slow down tracksolve

### DIFF
--- a/pastas/plotting/plots.py
+++ b/pastas/plotting/plots.py
@@ -582,6 +582,7 @@ class TrackSolve:
         tmin: Timestamp | str | None = None,
         tmax: Timestamp | str | None = None,
         update_iter: int | None = None,
+        pause=1e-10,
     ) -> None:
         logger.warning(
             "TrackSolve feature under development. If you find any bugs please post "
@@ -596,6 +597,7 @@ class TrackSolve:
             )
         else:
             self.update_iter = update_iter  # update plot every update_iter
+        self.pause = pause  # pause time for plot update, set to 0 for no pause
 
         # get tmin/tmax
         if tmin is None:
@@ -897,7 +899,7 @@ class TrackSolve:
         self.ax0.set_title(
             "Iteration: {0} (EVP: {1:.2f}%)".format(self.itercount, self.evp[-1])
         )
-        plt.pause(1e-10)
+        plt.pause(self.pause)
         self.fig.canvas.draw()
 
     def plot_track_solve_history(self, fig: Figure | None = None) -> list[Axes]:

--- a/pastas/plotting/plots.py
+++ b/pastas/plotting/plots.py
@@ -582,7 +582,7 @@ class TrackSolve:
         tmin: Timestamp | str | None = None,
         tmax: Timestamp | str | None = None,
         update_iter: int | None = None,
-        pause=1e-10,
+        pause: float = 1e-10,
     ) -> None:
         logger.warning(
             "TrackSolve feature under development. If you find any bugs please post "


### PR DESCRIPTION
Small silly change to configure how quickly tracksolve updates the plots (and performs the solve). Useful for demos.
