### PR TITLE
Fix failing test routines

### DIFF
--- a/.github/workflows/test_benchmark_notebooks.yml
+++ b/.github/workflows/test_benchmark_notebooks.yml
@@ -38,7 +38,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_format_lint.yml
+++ b/.github/workflows/test_format_lint.yml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: |
@@ -46,4 +46,3 @@ jobs:
 
       - name: Test
         run: uv run tox -e ${{ matrix.toxenv }} --skip-pkg-install
-

--- a/.github/workflows/test_pasfiles.yml
+++ b/.github/workflows/test_pasfiles.yml
@@ -40,7 +40,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_spelling.yml
+++ b/.github/workflows/test_spelling.yml
@@ -15,7 +15,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -63,7 +63,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: |
@@ -77,7 +77,8 @@ jobs:
         run: uv run tox -e ${{ matrix.toxenv }} --skip-pkg-install
 
       - name: Run codacy-coverage-reporter
-        if: ${{ matrix.toxenv == 'all' && github.repository == 'pastas/pastas' && success() }}
+        if: ${{ matrix.toxenv == 'all' && github.repository == 'pastas/pastas' &&
+          success() }}
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
# Short description

This PR fixes a CI failure caused by uv cache deserialization during the tox package installation step. To make the workflow stable, it disables uv caching in the affected job. This avoids intermittent cache-related failures and allows the CI run to proceed normally.