### PR TITLE
add StatTimer displaying user-specified stats in progress indicator

### DIFF
--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -19,9 +19,11 @@ This will print the following to the console::
 
 """
 
+from typing import Literal
+
 from pastas.decorators import PastasDeprecationWarning
 from pastas.stats import metrics
-from pastas.typing import Literal, Model
+from pastas.typing import Model
 
 
 @PastasDeprecationWarning(

--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -20,6 +20,7 @@ This will print the following to the console::
 """
 
 from pastas.decorators import PastasDeprecationWarning
+import numpy as np
 
 
 @PastasDeprecationWarning(
@@ -83,3 +84,34 @@ class SolveTimer(tqdm):
                     f"Model solve time exceeded {self.max_time} seconds!"
                 )
         return displayed
+
+
+class RMSETimer(SolveTimer):
+    """SolveTimer that also displays RMSE for each iteration."""
+
+    def __init__(self, ml, *args, update_interval=None, **kwargs) -> None:
+        """
+        Parameters
+        ----------
+        ml : pastas.Model
+            The model being solved, used to compute residuals.
+        update_interval : int, optional
+            Number of iterations between RMSE updates. If None (default), the
+            RMSE is updated when iteration % number of varying parameters == 0.
+        """
+        self.ml = ml
+        if update_interval is not None:
+            self.update_interval = update_interval
+        else:
+            self.update_interval = self.ml.parameters.vary.sum()
+        super().__init__(*args, **kwargs)
+
+    def timer(self, p, n: int = 1):
+        """Callback method that updates RMSE in the progress bar."""
+        # extra overhead to compute residuals again, though with caching
+        # this will be faster
+        if (self.n % self.update_interval) == 0:
+            residuals = self.ml.residuals(p)
+            rmse = np.sqrt((residuals**2).mean())
+            self.set_postfix(RMSE=f"{rmse:.4e}")
+        return super().timer(p, n)

--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -19,8 +19,6 @@ This will print the following to the console::
 
 """
 
-import numpy as np
-
 from pastas.decorators import PastasDeprecationWarning
 from pastas.stats import metrics
 

--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -59,7 +59,7 @@ class SolveTimer(tqdm):
     updated quite as nicely.
     """
 
-    def __init__(self, max_time: float | None = None, *args, **kwargs) -> None:
+    def __init__(self, *args, max_time: float | None = None, **kwargs) -> None:
         """Initialize SolveTimer.
 
         Parameters
@@ -87,9 +87,9 @@ class SolveTimer(tqdm):
 
 
 class RMSETimer(SolveTimer):
-    """SolveTimer that also displays RMSE for each iteration."""
+    """SolveTimer that displays current RMSE each N iterations."""
 
-    def __init__(self, ml, *args, update_interval=None, **kwargs) -> None:
+    def __init__(self, ml, *args, update_interval: int | None = None, **kwargs) -> None:
         """
         Parameters
         ----------

--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -21,6 +21,7 @@ This will print the following to the console::
 
 from pastas.decorators import PastasDeprecationWarning
 from pastas.stats import metrics
+from pastas.typing import Literal, Model
 
 
 @PastasDeprecationWarning(
@@ -90,7 +91,14 @@ class StatTimer(SolveTimer):
     """StatTimer that updates a user-specified solve statistic every N iterations."""
 
     def __init__(
-        self, ml, *args, statistic="rmse", update_interval: int | None = None, **kwargs
+        self,
+        ml: Model,
+        *args,
+        statistic: Literal[
+            "rmse", "sse", "mae", "rsq", "evp", "nse", "nnse", "aic", "aicc", "bic"
+        ] = "rmse",
+        update_interval: int | None = None,
+        **kwargs,
     ) -> None:
         """
         Parameters

--- a/pastas/timer.py
+++ b/pastas/timer.py
@@ -19,8 +19,10 @@ This will print the following to the console::
 
 """
 
-from pastas.decorators import PastasDeprecationWarning
 import numpy as np
+
+from pastas.decorators import PastasDeprecationWarning
+from pastas.stats import metrics
 
 
 @PastasDeprecationWarning(
@@ -86,15 +88,20 @@ class SolveTimer(tqdm):
         return displayed
 
 
-class RMSETimer(SolveTimer):
-    """SolveTimer that displays current RMSE each N iterations."""
+class StatTimer(SolveTimer):
+    """StatTimer that updates a user-specified solve statistic every N iterations."""
 
-    def __init__(self, ml, *args, update_interval: int | None = None, **kwargs) -> None:
+    def __init__(
+        self, ml, *args, statistic="rmse", update_interval: int | None = None, **kwargs
+    ) -> None:
         """
         Parameters
         ----------
         ml : pastas.Model
             The model being solved, used to compute residuals.
+        statistic : str, optional
+            The statistic to compute and display, by default "rmse". Must be a valid
+            statistic in pastas.stats.metrics that accepts ``res=`` as an argument.
         update_interval : int, optional
             Number of iterations between RMSE updates. If None (default), the
             RMSE is updated when iteration % number of varying parameters == 0.
@@ -104,6 +111,8 @@ class RMSETimer(SolveTimer):
             self.update_interval = update_interval
         else:
             self.update_interval = self.ml.parameters.vary.sum()
+        self.statistic = statistic
+        self.func = getattr(metrics, self.statistic)
         super().__init__(*args, **kwargs)
 
     def timer(self, p, n: int = 1):
@@ -111,7 +120,10 @@ class RMSETimer(SolveTimer):
         # extra overhead to compute residuals again, though with caching
         # this will be faster
         if (self.n % self.update_interval) == 0:
-            residuals = self.ml.residuals(p)
-            rmse = np.sqrt((residuals**2).mean())
-            self.set_postfix(RMSE=f"{rmse:.4e}")
+            if self.ml.noisemodel is not None:
+                rv = self.ml.noise(p) * self.ml.noise_weights(p)
+            else:
+                rv = self.ml.residuals(p)
+            stat = self.func(res=rv)
+            self.set_postfix(**{f"{self.statistic.upper()}": f"{stat:.4e}"})
         return super().timer(p, n)


### PR DESCRIPTION
# Short description
- updates RMSE value every N iterations in the waitbar
- useful for slow models to check if your solution is getting anywhere (i.e. single-cell UZF MODFLOW models)

# Checklist before PR can be merged:
- [x] is documented
- [x] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [x] type hints
- [ ] tests added or expanded
- [x] remove output for all notebooks with changes
- [ ] example notebook (for new features)