### PR TITLE
Pin dependency upper versions for package versions that will (most likely) break Pastas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,13 @@ maintainers = [
     { name = "O.N. Ebbens", email = "o.ebbens@artesia-water.nl" },
     { name = "M.A. Vonk", email = "vonk.mart@gmail.com" },
 ]
-requires-python = ">= 3.11"
+requires-python = ">= 3.11, < 3.15"
 dependencies = [
-    "numpy >= 2.0.0",
-    "matplotlib >= 3.9.0",
+    "numpy >= 2.0.0, < 3.0",
+    "matplotlib >= 3.9.0, < 4.0",
     "pandas >= 2.2.0, < 4.0",
-    "scipy >= 1.13.0",
-    "numba >= 0.60.0",
+    "scipy >= 1.13.0, < 2.0",
+    "numba >= 0.60.0, < 1.0",
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [


### PR DESCRIPTION
Pin dependency upper versions for package versions that will (most likely) break Pastas. If a dependency announces a version with big changes we should do a pin the version lower. But that's what I think is the best solution for now.