### PR TITLE
Add root finding for exact tmax in FourParam response function

### DIFF
--- a/pastas/check.py
+++ b/pastas/check.py
@@ -242,7 +242,8 @@ def _response_memory(
                 ]
         else:
             if sm.rfunc._name in ("Hantush", "FourParam"):
-                # get_tmax for Hantush has an approximation which can be overridden
+                 # get_tmax for Hantush and FourParam has an approximation which
+                 # can be overridden by setting approximate_tmax=False
                 rfunc = type(sm.rfunc)(quad=sm.rfunc.quad, approximate_tmax=False)
                 p = ml.get_parameters(sm_name)
                 p = p[0:3] if sm.rfunc._name == "Hantush" else p[0:4]

--- a/pastas/check.py
+++ b/pastas/check.py
@@ -244,7 +244,8 @@ def _response_memory(
             if sm.rfunc._name in ("Hantush", "FourParam"):
                 # get_tmax for Hantush has an approximation which can be overridden
                 rfunc = type(sm.rfunc)(quad=sm.rfunc.quad, approximate_tmax=False)
-                p = ml.get_parameters(sm_name)[0:3] if sm.rfunc._name == "Hantush" else ml.get_parameters(sm_name)[0:4]
+                p = ml.get_parameters(sm_name)
+                p = p[0:3] if sm.rfunc._name == "Hantush" else p[0:4]
                 tmem = rfunc.get_tmax(p, cutoff=cutoff)
             else:
                 # for response functions where get_tmax is exact

--- a/pastas/check.py
+++ b/pastas/check.py
@@ -241,10 +241,10 @@ def _response_memory(
                     "",
                 ]
         else:
-            if sm.rfunc._name == "Hantush":
+            if sm.rfunc._name in ("Hantush", "FourParam"):
                 # get_tmax for Hantush has an approximation which can be overridden
                 rfunc = type(sm.rfunc)(quad=sm.rfunc.quad, approximate_tmax=False)
-                p = ml.get_parameters(sm_name)[0:3]
+                p = ml.get_parameters(sm_name)[0:3] if sm.rfunc._name == "Hantush" else ml.get_parameters(sm_name)[0:4]
                 tmem = rfunc.get_tmax(p, cutoff=cutoff)
             else:
                 # for response functions where get_tmax is exact

--- a/pastas/check.py
+++ b/pastas/check.py
@@ -242,8 +242,8 @@ def _response_memory(
                 ]
         else:
             if sm.rfunc._name in ("Hantush", "FourParam"):
-                 # get_tmax for Hantush and FourParam has an approximation which
-                 # can be overridden by setting approximate_tmax=False
+                # get_tmax for Hantush and FourParam has an approximation which
+                # can be overridden by setting approximate_tmax=False
                 rfunc = type(sm.rfunc)(quad=sm.rfunc.quad, approximate_tmax=False)
                 p = ml.get_parameters(sm_name)
                 p = p[0:3] if sm.rfunc._name == "Hantush" else p[0:4]

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1597,8 +1597,6 @@ class FourParam(RfuncBase):
             Approximated tmax in days.
         """
         cutoff = self.cutoff if cutoff is None else cutoff
-        if not 0.0 < cutoff < 1.0:
-            raise ValueError("Cutoff must be between 0 and 1.")
 
         # Because Model.get_response_tmax() provides parameters for the stressmodel,
         # not only the response functions

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1605,34 +1605,7 @@ class FourParam(RfuncBase):
         if len(p) > 4:
             p = p[:4]
 
-        return self._tmax_from_log_cdf(p=p, cutoff=cutoff, n_grid=4000)
-
-    @staticmethod
-    def _impulse_integral(p: ArrayLike) -> float:
-        """Analytical integral of FourParam impulse over [0, inf)."""
-        _, n, a, b = p
-        if a <= 0.0 or b <= 0.0:
-            return np.nan
-        scale = a * np.sqrt(b)
-        arg = 2.0 * np.sqrt(b)
-        integral = 2.0 * (scale**n) * kv(n, arg)
-        return float(integral)
-
-    @staticmethod
-    def _impulse_log_integrand(u: ArrayLike, p: ArrayLike) -> ArrayLike:
-        """Impulse integrand transformed to log-time (t = exp(u))."""
-        _, n, a, b = p
-        t = np.exp(u)
-        return np.exp(n * u - t / a - (a * b) / t)
-
-    def _tmax_from_log_cdf(
-        self,
-        p: ArrayLike,
-        cutoff: float,
-        n_grid: int,
-    ) -> float:
-        """Compute tmax by integrating cumulative mass on a log-time grid."""
-        impulse_integral = self._impulse_integral(p)
+        impulse_integral = self._impulse_integral_for_mode(p)
         if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
             logger.warning(
                 "Unable to compute FourParam tmax due to invalid normalization "
@@ -1647,8 +1620,8 @@ class FourParam(RfuncBase):
         frac_max = 0.0
 
         while frac_max < cutoff and u_max <= max_u:
-            u = np.linspace(u_min, u_max, n_grid)
-            fu = self._impulse_log_integrand(u, p)
+            u = np.linspace(u_min, u_max, 4000)
+            fu = self._integrand_fourparam(u, p)
             cum = np.zeros_like(u)
             cum[1:] = np.cumsum(0.5 * (fu[1:] + fu[:-1]) * np.diff(u))
             frac = cum / impulse_integral
@@ -1672,6 +1645,25 @@ class FourParam(RfuncBase):
         idx = min(max(idx, 0), len(u) - 1)
         return float(np.exp(u[idx]))
 
+    def _impulse_integral(self, p: ArrayLike) -> float:
+        """Integral of FourParam impulse over [0, inf)."""
+        if self.quad:
+            q = quad(self.impulse, 0, np.inf, args=p)[0]
+            return float(q)
+
+        _, n, a, b = p
+        scale = a * np.sqrt(b)
+        arg = 2.0 * np.sqrt(b)
+        integral = 2.0 * (scale**n) * kv(n, arg)
+        return float(integral)
+
+    @staticmethod
+    def _integrand_fourparam(u: ArrayLike, p: ArrayLike) -> ArrayLike:
+        """Impulse integrand transformed to log-time (t = exp(u))."""
+        _, n, a, b = p
+        t = np.exp(u)
+        return np.exp(n * u - t / a - (a * b) / t)
+
     def _f_step(
         self,
         t: float,
@@ -1683,13 +1675,17 @@ class FourParam(RfuncBase):
         if t <= 0.0:
             return -cutoff
 
+        if self.quad:
+            step_value = quad(self.impulse, 0, t, args=p)[0] / impulse_integral
+            return step_value - cutoff
+
         u_upper = np.log(t)
         # Integrate in log-time for numerical stability at very small t.
         if u_upper <= -80.0:
             step_value = 0.0
         else:
             step_value = (
-                quad(self._impulse_log_integrand, -80.0, u_upper, args=(p,))[0]
+                quad(self._integrand_fourparam, -80.0, u_upper, args=(p,))[0]
                 / impulse_integral
             )
         return step_value - cutoff
@@ -1795,13 +1791,15 @@ class FourParam(RfuncBase):
         if len(p) > 4:
             p = p[:4]
 
+        impulse_integral = self._impulse_integral(p)
+
         if self.quad:
             t = self.get_t(p=p, dt=dt, cutoff=cutoff, maxtmax=maxtmax, **kwargs)
             s = np.zeros_like(t)
             s[0] = quad(self.impulse, 0, dt, args=p)[0]
             for i in range(1, len(t)):
                 s[i] = s[i - 1] + quad(self.impulse, t[i - 1], t[i], args=p)[0]
-            s = s * (p[0] / self._impulse_integral(p))
+            s = s * (p[0] / impulse_integral)
             return s
 
         else:
@@ -1831,7 +1829,7 @@ class FourParam(RfuncBase):
                 s[1:] = s[0] + np.cumsum(
                     step / 6 * (func[:-1] + 4 * func_half + func[1:])
                 )
-                s = s * (p[0] / self._impulse_integral(p))
+                s = s * (p[0] / impulse_integral)
                 return s[int(dt / step - 1) :: int(dt / step)]
             else:
                 t = self.get_t(p=p, dt=dt, cutoff=cutoff, maxtmax=maxtmax, **kwargs)
@@ -1850,7 +1848,7 @@ class FourParam(RfuncBase):
                 s[1:] = s[0] + np.cumsum(
                     dt / 6 * (func[:-1] + 4 * func_half + func[1:])
                 )
-                s = s * (self.gain(p) / self._impulse_integral(p))
+                s = s * (self.gain(p) / impulse_integral)
                 return s
 
     def block_from_impulse(

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1630,16 +1630,16 @@ class FourParam(RfuncBase):
             func = self.impulse(x, p)
             func_half = self.impulse(x[:-1] + 0.5, p)
 
+            y[0] = 0.5 * (
+                w1 * self.impulse(0.5 * t1 + 0.5, p)
+                + w2 * self.impulse(0.5 * t2 + 0.5, p)
+                + w3 * self.impulse(0.5 * t3 + 0.5, p)
+            )
             if self.quad:
                 y[1:] = y[0] + np.cumsum(
                     1.0 / 6.0 * (func[:-1] + 4.0 * func_half + func[1:])
                 )
             else:
-                y[0] = 0.5 * (
-                    w1 * self.impulse(0.5 * t1 + 0.5, p)
-                    + w2 * self.impulse(0.5 * t2 + 0.5, p)
-                    + w3 * self.impulse(0.5 * t3 + 0.5, p)
-                )
                 y[1:] = y[0] + np.cumsum(
                     1.0 / 6.0 * (func[:-1] + 4.0 * func_half + func[1:])
                 )

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1598,13 +1598,8 @@ class FourParam(RfuncBase):
         """
         cutoff = self.cutoff if cutoff is None else cutoff
 
-        # Because Model.get_response_tmax() provides parameters for the stressmodel,
-        # not only the response functions
-        if len(p) > 4:
-            p = p[:4]
-
         impulse_integral = self._impulse_integral(p)
-        if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
+        if np.isinf(impulse_integral) or impulse_integral <= 0.0:
             logger.warning(
                 "Unable to compute FourParam tmax due to invalid normalization "
                 "integral (value=%s). Returning 1.0 day.",
@@ -1705,11 +1700,6 @@ class FourParam(RfuncBase):
         """
         cutoff = self.cutoff if cutoff is None else cutoff
 
-        # Because Model.get_response_tmax() provides parameters for the stressmodel,
-        # not only the response functions
-        if len(p) > 4:
-            p = p[:4]
-
         t0 = self.get_tmax_approximation(p, cutoff)
         if self.approximate_tmax:
             return t0
@@ -1784,10 +1774,6 @@ class FourParam(RfuncBase):
         maxtmax: float | None = None,
         **kwargs,
     ) -> ArrayLike:
-        # Because Model.get_response_tmax() provides parameters for the stressmodel,
-        # not only the response functions
-        if len(p) > 4:
-            p = p[:4]
 
         impulse_integral = self._impulse_integral(p)
 

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1516,6 +1516,9 @@ class FourParam(RfuncBase):
     quad: bool, optional
         If true, use the 'quad' method from scipy.integrate to integrate the impulse
         response function. This may be more accurate but increases computation times.
+    approximate_tmax: bool, optional
+        If True, get_tmax will use a fast numerical approximation (default). If False,
+        it will use the exact numerical root finding method.
 
     Attributes
     ----------
@@ -1537,10 +1540,12 @@ class FourParam(RfuncBase):
         cutoff: float = 0.999,
         use_block: bool = True,
         quad: bool = False,
+        approximate_tmax: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(cutoff=cutoff, use_block=use_block, **kwargs)
         self.quad = quad
+        self.approximate_tmax = approximate_tmax
 
     @property
     def nparam(self) -> int:
@@ -1574,44 +1579,185 @@ class FourParam(RfuncBase):
         )
         return parameters
 
-    def get_tmax(self, p: ArrayLike, cutoff: float | None = None) -> float:
-        if cutoff is None:
-            cutoff = self.cutoff
+    def get_tmax_approximation(
+        self, p: ArrayLike, cutoff: float | None = None
+    ) -> float:
+        """Approximate tmax using adaptive cumulative integration.
+
+        Parameters
+        ----------
+        p : array_like
+            Response function parameters `[A, n, a, b]`.
+        cutoff : float, optional
+            Fraction of the total step response reached at tmax.
+
+        Returns
+        -------
+        float
+            Approximated tmax in days.
+        """
+        cutoff = self.cutoff if cutoff is None else cutoff
 
         # Because Model.get_response_tmax() provides parameters for the stressmodel,
         # not only the response functions
         if len(p) > 4:
             p = p[:4]
 
-        if self.quad:
-            x = np.arange(1, 10000, 1)
-            y = np.zeros_like(x)
-            func = self.impulse(x, p)
-            func_half = self.impulse(x[:-1] + 1 / 2, p)
-            y[1:] = y[0] + np.cumsum(1 / 6 * (func[:-1] + 4 * func_half + func[1:]))
-            y = y / quad(self.impulse, 0, np.inf, args=p)[0]
-            return np.searchsorted(y, cutoff)
-
-        else:
-            t1 = -np.sqrt(3 / 5)
-            t2 = 0
-            t3 = np.sqrt(3 / 5)
-            w1 = 5 / 9
-            w2 = 8 / 9
-            w3 = 5 / 9
-
-            x = np.arange(1, 10000, 1)
-            y = np.zeros_like(x)
-            func = self.impulse(x, p)
-            func_half = self.impulse(x[:-1] + 1 / 2, p)
-            y[0] = 0.5 * (
-                w1 * self.impulse(0.5 * t1 + 0.5, p)
-                + w2 * self.impulse(0.5 * t2 + 0.5, p)
-                + w3 * self.impulse(0.5 * t3 + 0.5, p)
+        impulse_integral = quad(self.impulse, 0, np.inf, args=p)[0]
+        if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
+            logger.warning(
+                "Unable to compute FourParam tmax approximation due to invalid "
+                "normalization integral (value=%s). Returning 1.0 day.",
+                impulse_integral,
             )
-            y[1:] = y[0] + np.cumsum(1 / 6 * (func[:-1] + 4 * func_half + func[1:]))
-            y = y / quad(self.impulse, 0, np.inf, args=p)[0]
-            return np.searchsorted(y, cutoff)
+            return 1.0
+
+        t1 = -np.sqrt(3 / 5)
+        t2 = 0
+        t3 = np.sqrt(3 / 5)
+        w1 = 5 / 9
+        w2 = 8 / 9
+        w3 = 5 / 9
+
+        # Start from a parameter-based scale and expand until cutoff is reached.
+        max_t = max(256, int(np.ceil(p[2] * p[3])))
+        max_t_hard = 1_000_000
+
+        while True:
+            x = np.arange(1, max_t + 1, dtype=float)
+            y = np.zeros_like(x)
+
+            func = self.impulse(x, p)
+            func_half = self.impulse(x[:-1] + 0.5, p)
+
+            if self.quad:
+                y[1:] = y[0] + np.cumsum(
+                    1.0 / 6.0 * (func[:-1] + 4.0 * func_half + func[1:])
+                )
+            else:
+                y[0] = 0.5 * (
+                    w1 * self.impulse(0.5 * t1 + 0.5, p)
+                    + w2 * self.impulse(0.5 * t2 + 0.5, p)
+                    + w3 * self.impulse(0.5 * t3 + 0.5, p)
+                )
+                y[1:] = y[0] + np.cumsum(
+                    1.0 / 6.0 * (func[:-1] + 4.0 * func_half + func[1:])
+                )
+
+            y /= impulse_integral
+            idx = np.searchsorted(y, cutoff)
+            if idx < len(x):
+                return float(x[idx])
+
+            if max_t >= max_t_hard:
+                logger.warning(
+                    "FourParam tmax approximation hit maximum search limit (%s days) "
+                    "without reaching cutoff=%s. Returning search limit.",
+                    max_t_hard,
+                    cutoff,
+                )
+                return float(max_t)
+
+            max_t = min(max_t * 2, max_t_hard)
+
+    def _f_step(
+        self,
+        t: float,
+        p: ArrayLike,
+        cutoff: float,
+        impulse_integral: float,
+    ) -> float:
+        """Objective function for exact tmax root finding."""
+        step_value = quad(self.impulse, 0, t, args=p)[0] / impulse_integral
+        return step_value - cutoff
+
+    def get_tmax(self, p: ArrayLike, cutoff: float | None = None) -> float:
+        """Calculate `tmax` using approximation or root finding.
+
+        Parameters
+        ----------
+        p: array_like
+            Response function parameters.
+        cutoff: float, optional
+            Fraction of the step response used to determine the response cutoff.
+
+        Returns
+        -------
+        float
+            Response time in days corresponding to the selected cutoff.
+        """
+        cutoff = self.cutoff if cutoff is None else cutoff
+
+        # Because Model.get_response_tmax() provides parameters for the stressmodel,
+        # not only the response functions
+        if len(p) > 4:
+            p = p[:4]
+
+        t0 = self.get_tmax_approximation(p, cutoff)
+        if self.approximate_tmax:
+            return t0
+
+        impulse_integral = quad(self.impulse, 0, np.inf, args=p)[0]
+        if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
+            logger.warning(
+                "Unable to compute exact FourParam tmax due to invalid normalization "
+                "integral (value=%s). Returning approximate tmax.",
+                impulse_integral,
+            )
+            return t0
+
+        tol = min(10.0 ** np.floor(np.log10(max(t0, 1.0))) / 1e2, 0.1)
+        lower = 1e-30
+        upper = max(t0, 1.0)
+
+        f_upper = self._f_step(upper, p, cutoff, impulse_integral)
+        max_upper = 1e7
+        while f_upper < 0.0 and upper < max_upper:
+            upper *= 2.0
+            f_upper = self._f_step(upper, p, cutoff, impulse_integral)
+
+        if f_upper < 0.0:
+            logger.warning(
+                "Could not bracket exact FourParam tmax up to %s days for cutoff=%s. "
+                "Returning approximate tmax.",
+                max_upper,
+                cutoff,
+            )
+            return t0
+
+        try:
+            root, info = brentq(
+                f=self._f_step,
+                a=lower,
+                b=upper,
+                xtol=tol,
+                maxiter=100,
+                args=(p, cutoff, impulse_integral),
+                full_output=True,
+                disp=False,
+            )
+        except ValueError as err:
+            logger.warning(
+                "Exact FourParam tmax root finding failed (%s). Returning approximate "
+                "tmax.",
+                err,
+            )
+            return t0
+
+        if info.converged:
+            logger.debug(
+                "Root finding for FourParam tmax converged successfully. "
+                "Brentq RootResults: %s",
+                info,
+            )
+            return root
+
+        logger.warning(
+            "Root finding for FourParam tmax did not converge, returning "
+            "approximate tmax. Brentq RootResults: %s",
+            info,
+        )
+        return t0
 
     def gain(self, p: ArrayLike) -> float:
         return p[0]
@@ -1729,7 +1875,10 @@ class FourParam(RfuncBase):
         return (t ** (n - 1)) * np.exp(-t / a - a * b / t)
 
     def to_dict(self):
-        settings = super().to_dict() | {"quad": self.quad}
+        settings = super().to_dict() | {
+            "quad": self.quad,
+            "approximate_tmax": self.approximate_tmax,
+        }
         return settings
 
 

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1582,7 +1582,7 @@ class FourParam(RfuncBase):
     def get_tmax_approximation(
         self, p: ArrayLike, cutoff: float | None = None
     ) -> float:
-        """Approximate tmax using adaptive cumulative integration.
+        """Approximate tmax using adaptive cumulative integration in log-time.
 
         Parameters
         ----------
@@ -1597,68 +1597,91 @@ class FourParam(RfuncBase):
             Approximated tmax in days.
         """
         cutoff = self.cutoff if cutoff is None else cutoff
+        if not 0.0 < cutoff < 1.0:
+            raise ValueError("Cutoff must be between 0 and 1.")
 
         # Because Model.get_response_tmax() provides parameters for the stressmodel,
         # not only the response functions
         if len(p) > 4:
             p = p[:4]
 
-        impulse_integral = quad(self.impulse, 0, np.inf, args=p)[0]
+        return self._tmax_from_log_cdf(
+            p=p, cutoff=cutoff, n_grid=4000, conservative=True
+        )
+
+    @staticmethod
+    def _impulse_integral(p: ArrayLike) -> float:
+        """Analytical integral of FourParam impulse over [0, inf)."""
+        _, n, a, b = p
+        if a <= 0.0 or b <= 0.0:
+            return np.nan
+        scale = a * np.sqrt(b)
+        arg = 2.0 * np.sqrt(b)
+        integral = 2.0 * (scale**n) * kv(n, arg)
+        return float(integral)
+
+    @staticmethod
+    def _impulse_log_integrand(u: ArrayLike, p: ArrayLike) -> ArrayLike:
+        """Impulse integrand transformed to log-time (t = exp(u))."""
+        _, n, a, b = p
+        t = np.exp(u)
+        return np.exp(n * u - t / a - (a * b) / t)
+
+    def _tmax_from_log_cdf(
+        self,
+        p: ArrayLike,
+        cutoff: float,
+        n_grid: int,
+        conservative: bool = False,
+    ) -> float:
+        """Compute tmax by integrating cumulative mass on a log-time grid."""
+        impulse_integral = self._impulse_integral(p)
         if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
             logger.warning(
-                "Unable to compute FourParam tmax approximation due to invalid "
-                "normalization integral (value=%s). Returning 1.0 day.",
+                "Unable to compute FourParam tmax due to invalid normalization "
+                "integral (value=%s). Returning 1.0 day.",
                 impulse_integral,
             )
             return 1.0
 
-        t1 = -np.sqrt(3 / 5)
-        t2 = 0
-        t3 = np.sqrt(3 / 5)
-        w1 = 5 / 9
-        w2 = 8 / 9
-        w3 = 5 / 9
+        u_min = -40.0
+        u_max = 20.0
+        max_u = 40.0
+        frac_max = 0.0
 
-        # Start from a parameter-based scale and expand until cutoff is reached.
-        max_t_hard = 1_000_000
-        max_t = min(max(256, int(np.ceil(p[2] * p[3]))), max_t_hard)
+        while frac_max < cutoff and u_max <= max_u:
+            u = np.linspace(u_min, u_max, n_grid)
+            fu = self._impulse_log_integrand(u, p)
+            cum = np.zeros_like(u)
+            cum[1:] = np.cumsum(0.5 * (fu[1:] + fu[:-1]) * np.diff(u))
+            frac = cum / impulse_integral
+            frac_max = float(frac[-1])
+            if frac_max < cutoff:
+                u_max += 5.0
 
-        while True:
-            x = np.arange(1, max_t + 1, dtype=float)
-            y = np.zeros_like(x)
-
-            func = self.impulse(x, p)
-            func_half = self.impulse(x[:-1] + 0.5, p)
-
-            y[0] = 0.5 * (
-                w1 * self.impulse(0.5 * t1 + 0.5, p)
-                + w2 * self.impulse(0.5 * t2 + 0.5, p)
-                + w3 * self.impulse(0.5 * t3 + 0.5, p)
+        if frac_max < cutoff:
+            logger.warning(
+                "FourParam tmax search hit maximum limit (%s days) without "
+                "reaching cutoff=%s. Returning search limit.",
+                np.exp(max_u),
+                cutoff,
             )
-            if self.quad:
-                y[1:] = y[0] + np.cumsum(
-                    1.0 / 6.0 * (func[:-1] + 4.0 * func_half + func[1:])
-                )
-            else:
-                y[1:] = y[0] + np.cumsum(
-                    1.0 / 6.0 * (func[:-1] + 4.0 * func_half + func[1:])
-                )
+            return float(np.exp(max_u))
 
-            y /= impulse_integral
-            idx = np.searchsorted(y, cutoff)
-            if idx < len(x):
-                return float(x[idx])
+        frac = np.clip(frac, 0.0, 1.0)
+        if conservative:
+            # Conservative mode returns the first grid point where cutoff is reached.
+            # This intentionally overestimates tmax versus interpolation.
+            idx = int(np.searchsorted(frac, cutoff, side="left"))
+            idx = min(max(idx, 0), len(u) - 1)
+            return float(np.exp(u[idx]))
 
-            if max_t >= max_t_hard:
-                logger.warning(
-                    "FourParam tmax approximation hit maximum search limit (%s days) "
-                    "without reaching cutoff=%s. Returning search limit.",
-                    max_t_hard,
-                    cutoff,
-                )
-                return float(max_t)
-
-            max_t = min(max_t * 2, max_t_hard)
+        frac_unique, idx = np.unique(frac, return_index=True)
+        u_unique = u[idx]
+        if frac_unique.size < 2:
+            return float(np.exp(u_unique[-1]))
+        u_tmax = np.interp(cutoff, frac_unique, u_unique)
+        return float(np.exp(u_tmax))
 
     def _f_step(
         self,
@@ -1668,7 +1691,18 @@ class FourParam(RfuncBase):
         impulse_integral: float,
     ) -> float:
         """Objective function for exact tmax root finding."""
-        step_value = quad(self.impulse, 0, t, args=p)[0] / impulse_integral
+        if t <= 0.0:
+            return -cutoff
+
+        u_upper = np.log(t)
+        # Integrate in log-time for numerical stability at very small t.
+        if u_upper <= -80.0:
+            step_value = 0.0
+        else:
+            step_value = (
+                quad(self._impulse_log_integrand, -80.0, u_upper, args=(p,))[0]
+                / impulse_integral
+            )
         return step_value - cutoff
 
     def get_tmax(self, p: ArrayLike, cutoff: float | None = None) -> float:
@@ -1697,7 +1731,7 @@ class FourParam(RfuncBase):
         if self.approximate_tmax:
             return t0
 
-        impulse_integral = quad(self.impulse, 0, np.inf, args=p)[0]
+        impulse_integral = self._impulse_integral(p)
         if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
             logger.warning(
                 "Unable to compute exact FourParam tmax due to invalid normalization "
@@ -1706,14 +1740,13 @@ class FourParam(RfuncBase):
             )
             return t0
 
-        tol = min(10.0 ** np.floor(np.log10(max(t0, 1.0))) / 1e2, 0.1)
         lower = 1e-30
-        upper = max(t0, 1.0)
+        upper = max(t0, lower * 10.0)
 
         f_upper = self._f_step(upper, p, cutoff, impulse_integral)
-        max_upper = 1e7
+        max_upper = float(np.exp(40.0))
         while f_upper < 0.0 and upper < max_upper:
-            upper *= 2.0
+            upper = min(upper * 2.0, max_upper)
             f_upper = self._f_step(upper, p, cutoff, impulse_integral)
 
         if f_upper < 0.0:
@@ -1725,13 +1758,16 @@ class FourParam(RfuncBase):
             )
             return t0
 
+        # Scale xtol with response timescale to keep absolute precision meaningful.
+        tol = min(max(upper * 1e-9, 1e-15), 1e-3)
+
         try:
             root, info = brentq(
                 f=self._f_step,
                 a=lower,
                 b=upper,
                 xtol=tol,
-                maxiter=100,
+                maxiter=200,
                 args=(p, cutoff, impulse_integral),
                 full_output=True,
                 disp=False,
@@ -1745,12 +1781,7 @@ class FourParam(RfuncBase):
             return t0
 
         if info.converged:
-            logger.debug(
-                "Root finding for FourParam tmax converged successfully. "
-                "Brentq RootResults: %s",
-                info,
-            )
-            return root
+            return float(root)
 
         logger.warning(
             "Root finding for FourParam tmax did not converge, returning "
@@ -1781,7 +1812,7 @@ class FourParam(RfuncBase):
             s[0] = quad(self.impulse, 0, dt, args=p)[0]
             for i in range(1, len(t)):
                 s[i] = s[i - 1] + quad(self.impulse, t[i - 1], t[i], args=p)[0]
-            s = s * (p[0] / (quad(self.impulse, 0, np.inf, args=p))[0])
+            s = s * (p[0] / self._impulse_integral(p))
             return s
 
         else:
@@ -1811,7 +1842,7 @@ class FourParam(RfuncBase):
                 s[1:] = s[0] + np.cumsum(
                     step / 6 * (func[:-1] + 4 * func_half + func[1:])
                 )
-                s = s * (p[0] / quad(self.impulse, 0, np.inf, args=p)[0])
+                s = s * (p[0] / self._impulse_integral(p))
                 return s[int(dt / step - 1) :: int(dt / step)]
             else:
                 t = self.get_t(p=p, dt=dt, cutoff=cutoff, maxtmax=maxtmax, **kwargs)
@@ -1830,7 +1861,7 @@ class FourParam(RfuncBase):
                 s[1:] = s[0] + np.cumsum(
                     dt / 6 * (func[:-1] + 4 * func_half + func[1:])
                 )
-                s = s * (self.gain(p) / quad(self.impulse, 0, np.inf, args=p)[0])
+                s = s * (self.gain(p) / self._impulse_integral(p))
                 return s
 
     def block_from_impulse(

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1603,7 +1603,7 @@ class FourParam(RfuncBase):
         if len(p) > 4:
             p = p[:4]
 
-        impulse_integral = self._impulse_integral_for_mode(p)
+        impulse_integral = self._impulse_integral(p)
         if not np.isfinite(impulse_integral) or impulse_integral <= 0.0:
             logger.warning(
                 "Unable to compute FourParam tmax due to invalid normalization "

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1605,9 +1605,7 @@ class FourParam(RfuncBase):
         if len(p) > 4:
             p = p[:4]
 
-        return self._tmax_from_log_cdf(
-            p=p, cutoff=cutoff, n_grid=4000, conservative=True
-        )
+        return self._tmax_from_log_cdf(p=p, cutoff=cutoff, n_grid=4000)
 
     @staticmethod
     def _impulse_integral(p: ArrayLike) -> float:
@@ -1632,7 +1630,6 @@ class FourParam(RfuncBase):
         p: ArrayLike,
         cutoff: float,
         n_grid: int,
-        conservative: bool = False,
     ) -> float:
         """Compute tmax by integrating cumulative mass on a log-time grid."""
         impulse_integral = self._impulse_integral(p)
@@ -1669,19 +1666,11 @@ class FourParam(RfuncBase):
             return float(np.exp(max_u))
 
         frac = np.clip(frac, 0.0, 1.0)
-        if conservative:
-            # Conservative mode returns the first grid point where cutoff is reached.
-            # This intentionally overestimates tmax versus interpolation.
-            idx = int(np.searchsorted(frac, cutoff, side="left"))
-            idx = min(max(idx, 0), len(u) - 1)
-            return float(np.exp(u[idx]))
-
-        frac_unique, idx = np.unique(frac, return_index=True)
-        u_unique = u[idx]
-        if frac_unique.size < 2:
-            return float(np.exp(u_unique[-1]))
-        u_tmax = np.interp(cutoff, frac_unique, u_unique)
-        return float(np.exp(u_tmax))
+        # Conservative mode returns the first grid point where cutoff is reached.
+        # This intentionally overestimates tmax versus interpolation.
+        idx = int(np.searchsorted(frac, cutoff, side="left"))
+        idx = min(max(idx, 0), len(u) - 1)
+        return float(np.exp(u[idx]))
 
     def _f_step(
         self,

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1620,8 +1620,8 @@ class FourParam(RfuncBase):
         w3 = 5 / 9
 
         # Start from a parameter-based scale and expand until cutoff is reached.
-        max_t = max(256, int(np.ceil(p[2] * p[3])))
         max_t_hard = 1_000_000
+        max_t = min(max(256, int(np.ceil(p[2] * p[3]))), max_t_hard)
 
         while True:
             x = np.arange(1, max_t + 1, dtype=float)

--- a/tests/test_rfuncs.py
+++ b/tests/test_rfuncs.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy.integrate import quad
 
 import pastas as ps
 
@@ -394,6 +395,35 @@ def test_hantush_approximate_tmax_to_dict_roundtrip() -> None:
         tmax2 = rfunc2.get_tmax(p)
 
         assert tmax1 == tmax2, f"tmax values differ after roundtrip: {tmax1} vs {tmax2}"
+
+
+@pytest.mark.parametrize("approximate_tmax", [True, False])
+def test_fourparam_approximate_tmax_parameter(approximate_tmax: bool) -> None:
+    """Test that FourParam approximate_tmax parameter works and is preserved."""
+    rfunc = ps.FourParam(approximate_tmax=approximate_tmax)
+    p = rfunc.get_init_parameters("test").initial.to_numpy()
+
+    tmax = rfunc.get_tmax(p)
+    assert np.isfinite(tmax) and tmax > 0, f"Invalid tmax: {tmax}"
+
+    data = rfunc.to_dict()
+    assert data["approximate_tmax"] == approximate_tmax
+
+
+def test_fourparam_get_tmax_matches_normalized_step_cutoff() -> None:
+    """Regression test for FourParam tmax clipping at hard-coded search limits."""
+    cutoff = 0.999
+    p = [2.0, 1.0, 50.0, 100.0]
+    rfunc = ps.FourParam(approximate_tmax=True)
+
+    tmax = rfunc.get_tmax(p, cutoff=cutoff)
+    total = quad(rfunc.impulse, 0, np.inf, args=p)[0]
+    reached = quad(rfunc.impulse, 0, tmax, args=p)[0] / total
+
+    assert reached >= cutoff, (
+        f"FourParam tmax ({tmax}) should reach at least the target cutoff ({cutoff}), "
+        f"got {reached:.6f}"
+    )
 
 
 # Tests for HantushWellModel approximate_tmax and log_b options

--- a/tests/test_rfuncs.py
+++ b/tests/test_rfuncs.py
@@ -414,16 +414,56 @@ def test_fourparam_get_tmax_matches_normalized_step_cutoff() -> None:
     """Regression test for FourParam tmax clipping at hard-coded search limits."""
     cutoff = 0.999
     p = [2.0, 1.0, 50.0, 100.0]
-    rfunc = ps.FourParam(approximate_tmax=True)
+    rfunc_approx = ps.FourParam(approximate_tmax=True)
+    rfunc_exact = ps.FourParam(approximate_tmax=False)
 
-    tmax = rfunc.get_tmax(p, cutoff=cutoff)
-    total = quad(rfunc.impulse, 0, np.inf, args=p)[0]
-    reached = quad(rfunc.impulse, 0, tmax, args=p)[0] / total
+    tmax_approx = rfunc_approx.get_tmax(p, cutoff=cutoff)
+    tmax_exact = rfunc_exact.get_tmax(p, cutoff=cutoff)
 
-    assert reached >= cutoff, (
-        f"FourParam tmax ({tmax}) should reach at least the target cutoff ({cutoff}), "
-        f"got {reached:.6f}"
+    total = quad(rfunc_exact.impulse, 0, np.inf, args=p)[0]
+    reached_approx = quad(rfunc_exact.impulse, 0, tmax_approx, args=p)[0] / total
+    reached_exact = quad(rfunc_exact.impulse, 0, tmax_exact, args=p)[0] / total
+
+    assert reached_approx >= cutoff, (
+        f"Approximate FourParam tmax ({tmax_approx}) should be conservative for "
+        f"cutoff ({cutoff}), got {reached_approx:.6f}"
     )
+    assert abs(reached_exact - cutoff) < 1e-6, (
+        f"Exact FourParam tmax ({tmax_exact}) should satisfy cutoff equation. "
+        f"Expected {cutoff:.6f}, got {reached_exact:.6f}"
+    )
+
+
+def test_fourparam_tmax_negative_n_does_not_hit_hard_limit() -> None:
+    """Regression test for low-n FourParam cases that used to return huge tmax."""
+    p = [1.0, -10.0, 0.01, 1e-6]
+    cutoffs = [0.1, 0.5, 0.9, 0.99, 0.999]
+
+    rfunc_approx = ps.FourParam(approximate_tmax=True)
+    rfunc_exact = ps.FourParam(approximate_tmax=False)
+
+    previous_exact = 0.0
+    for cutoff in cutoffs:
+        tmax_approx = rfunc_approx.get_tmax(p, cutoff=cutoff)
+        tmax_exact = rfunc_exact.get_tmax(p, cutoff=cutoff)
+
+        assert tmax_approx < 1e5, (
+            f"Approximate tmax should not hit hard search limits, got {tmax_approx}"
+        )
+        assert tmax_exact < 1e5, (
+            f"Exact tmax should not hit hard search limits, got {tmax_exact}"
+        )
+
+        assert tmax_approx >= tmax_exact, (
+            f"Approximate tmax should be conservative (>= exact), "
+            f"approx={tmax_approx}, exact={tmax_exact}"
+        )
+
+        assert tmax_exact >= previous_exact, (
+            f"tmax should be non-decreasing with cutoff, got {tmax_exact} "
+            f"after {previous_exact}"
+        )
+        previous_exact = tmax_exact
 
 
 def test_fourparam_approximate_tmax_to_dict_roundtrip() -> None:

--- a/tests/test_rfuncs.py
+++ b/tests/test_rfuncs.py
@@ -426,6 +426,30 @@ def test_fourparam_get_tmax_matches_normalized_step_cutoff() -> None:
     )
 
 
+def test_fourparam_approximate_tmax_to_dict_roundtrip() -> None:
+    """Test that approximate_tmax survives to_dict/from_dict roundtrip for FourParam."""
+    for use_exact in [True, False]:
+        rfunc1 = ps.FourParam(approximate_tmax=not use_exact, cutoff=0.95)
+
+        data = rfunc1.to_dict()
+
+        rfunc_class = data.pop("class")
+        rfunc_up = data.pop("up", None)
+        rfunc_gsf = data.pop("gain_scale_factor", None)
+        rfunc2 = getattr(ps.rfunc, rfunc_class)(**data)
+        rfunc2.update_rfunc_settings(up=rfunc_up, gain_scale_factor=rfunc_gsf)
+
+        assert rfunc2.approximate_tmax == rfunc1.approximate_tmax, (
+            f"approximate_tmax not preserved: {rfunc1.approximate_tmax} vs {rfunc2.approximate_tmax}"
+        )
+
+        p = [2.0, 1.0, 50.0, 100.0]
+        tmax1 = rfunc1.get_tmax(p)
+        tmax2 = rfunc2.get_tmax(p)
+
+        assert tmax1 == tmax2, f"tmax values differ after roundtrip: {tmax1} vs {tmax2}"
+
+
 # Tests for HantushWellModel approximate_tmax and log_b options
 @pytest.mark.parametrize("log_b", [True, False])
 @pytest.mark.parametrize("approximate_tmax", [True, False])


### PR DESCRIPTION
# Short description
This pull request introduces improvements to the calculation of the `tmax` parameter for the `FourParam` response function in Pastas, aligning its implementation and options with those of the `Hantush` response function. The main changes include adding an `approximate_tmax` parameter to `FourParam`, implementing both approximate and exact (root-finding) methods for `tmax` calculation

## Changes
1. Added a new approximate_tmax setting for FourParam. If True: fast approximation, if False: exact root-finding for the cutoff condition
2. Reworked approximate tmax estimation using a log-time cumulative approach to fix extremely long tmax values (#209)

- [x] closes issue #209 