### PR TITLE
Fix bug overwriting tmin and tmax on adding stressmodel

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -103,10 +103,8 @@ def model_tmin_tmax(function: Callable) -> Callable:
         *args,
         **kwargs,
     ):
-        if tmin is None:
-            tmin = self.ml.settings["tmin"]
-        if tmax is None:
-            tmax = self.ml.settings["tmax"]
+        tmin = self.ml.settings["tmin"] if tmin is None else tmin
+        tmax = self.ml.settings["tmax"] if tmax is None else tmax
 
         return function(self, tmin, tmax, *args, **kwargs)
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -103,8 +103,8 @@ def model_tmin_tmax(function: Callable) -> Callable:
         *args,
         **kwargs,
     ):
-        tmin = self.ml.settings["tmin"] if tmin is None else tmin
-        tmax = self.ml.settings["tmax"] if tmax is None else tmax
+        tmin = self.ml.settings["tmin"] if tmin is None else Timestamp(tmin)
+        tmax = self.ml.settings["tmax"] if tmax is None else Timestamp(tmax)
 
         return function(self, tmin, tmax, *args, **kwargs)
 

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -455,8 +455,8 @@ class Model:
         looks with only the initial parameters and no calibration.
         """
         # Default options when tmin, tmax, freq and warmup are not provided.
-        tmin = self.settings["tmin"] if tmin is None else tmin
-        tmax = self.settings["tmax"] if tmax is None else tmax
+        tmin = self.settings["tmin"] if tmin is None else Timestamp(tmin)
+        tmax = self.settings["tmax"] if tmax is None else Timestamp(tmax)
 
         freq = self.settings["freq"] if freq is None else freq
         warmup = self.settings["warmup"] if warmup is None else _parse_warmup(warmup)
@@ -1366,7 +1366,7 @@ class Model:
         else:
             tmin = ts_tmin
 
-        return tmin
+        return Timestamp(tmin)
 
     def get_tmax(
         self,
@@ -1433,7 +1433,7 @@ class Model:
         else:
             tmax = ts_tmax
 
-        return tmax
+        return Timestamp(tmax)
 
     def get_init_parameters(self, initial: bool = True) -> DataFrame:
         """Method to get all initial parameters from the individual objects.

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -299,9 +299,6 @@ class Model:
                     "The stress of the stressmodel has no overlap with ml.oseries."
                 )
         self._check_stressmodel_compatibility()
-        tmin = self.get_tmin(use_oseries=True, use_stresses=True)
-        tmax = self.get_tmax(use_oseries=True, use_stresses=True)
-        self.set_settings(tmin=tmin, tmax=tmax)
 
     def add_constant(self, constant: Constant) -> None:
         """Add a Constant to the time series Model.

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -455,8 +455,16 @@ class Model:
         looks with only the initial parameters and no calibration.
         """
         # Default options when tmin, tmax, freq and warmup are not provided.
-        tmin = self.settings["tmin"] if tmin is None else Timestamp(tmin)
-        tmax = self.settings["tmax"] if tmax is None else Timestamp(tmax)
+        tmin = (
+            self.settings["tmin"]
+            if tmin is None
+            else self.get_tmin(tmin=tmin, use_oseries=False, use_stresses=True)
+        )
+        tmax = (
+            self.settings["tmax"]
+            if tmax is None
+            else self.get_tmax(tmax=tmax, use_oseries=False, use_stresses=True)
+        )
 
         freq = self.settings["freq"] if freq is None else freq
         warmup = self.settings["warmup"] if warmup is None else _parse_warmup(warmup)

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -455,14 +455,9 @@ class Model:
         looks with only the initial parameters and no calibration.
         """
         # Default options when tmin, tmax, freq and warmup are not provided.
-        if tmin is None and self.settings["tmin"]:
-            tmin = self.settings["tmin"]
-        else:
-            tmin = self.get_tmin(tmin, use_oseries=False, use_stresses=True)
-        if tmax is None and self.settings["tmax"]:
-            tmax = self.settings["tmax"]
-        else:
-            tmax = self.get_tmax(tmax, use_oseries=False, use_stresses=True)
+        tmin = self.settings["tmin"] if tmin is None else tmin
+        tmax = self.settings["tmax"] if tmax is None else tmax
+
         freq = self.settings["freq"] if freq is None else freq
         warmup = self.settings["warmup"] if warmup is None else _parse_warmup(warmup)
 
@@ -497,7 +492,11 @@ class Model:
         istart = 0  # Track parameters index to pass to stressmodel object
         for sm in self.stressmodels.values():
             contrib = sm.simulate(
-                p[istart : istart + sm.nparam], sim_index.min(), tmax, freq, dt
+                p=p[istart : istart + sm.nparam],
+                tmin=sim_index.min(),
+                tmax=tmax,
+                freq=freq,
+                dt=dt,
             )
             sim = sim.add(contrib)
             istart += sm.nparam

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -246,9 +246,9 @@ def _get_sim_index(
     Parameters
     ----------
     tmin : pandas.Timestamp
-        Timestamp of the end date for the simulation period.
-    tmax : pandas.Timestamp
         Timestamp of the start date for the simulation period.
+    tmax : pandas.Timestamp
+        Timestamp of the end date for the simulation period.
     freq : str
         String representing the desired frequency of the time series. Must be one
         of the following: (D, h, m, s, ms, us, ns) or a multiple of that e.g. "7D".
@@ -263,7 +263,7 @@ def _get_sim_index(
 
     """
     tmin = tmin.floor(freq) + time_offset
-    sim_index = date_range(tmin, tmax, freq=freq)
+    sim_index = date_range(start=tmin, end=tmax, freq=freq)
     return sim_index
 
 

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -267,7 +267,7 @@ def _get_sim_index(
     return sim_index
 
 
-def _parse_warmup(warmup):
+def _parse_warmup(warmup: Timedelta | float | int | str) -> Timedelta:
     """Parse the warmup period to a pandas Timedelta.
 
     Parameters


### PR DESCRIPTION
Fixes a bug where tmin and tmax are changed when adding a stressmodel. I thought this was standard pastas behaviour in #1140 but it was not so :) I also made some extra changes to simulate because settings["tmin"] and settings["tmax"] are never none anymore.