### PR TITLE
Make NoiseModelBase an AbstractBaseClass

### DIFF
--- a/pastas/model.py
+++ b/pastas/model.py
@@ -347,8 +347,8 @@ class Model:
 
         Parameters
         ----------
-        noisemodel: pastas.noisemodels.NoiseModelBase
-            Instance of NoiseModelBase.
+        noisemodel: NoiseModelType
+            Instance of a noise model class.
 
         Examples
         --------

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -17,6 +17,7 @@ See Also
 pastas.model.Model.add_noisemodel
 """
 
+from abc import ABC, abstractmethod
 from logging import getLogger
 
 import numpy as np
@@ -31,31 +32,32 @@ logger = getLogger(__name__)
 __all__ = ["ArNoiseModel", "ArmaNoiseModel"]
 
 
-class NoiseModelBase:
-    _name = "NoiseModelBase"
+class NoiseModelBase(ABC):
+    """Base class for noise models."""
 
-    def __init__(self) -> None:
-        self.nparam = 1
-        self.name = "noise"
-        self.norm = None
+    def __init__(self, name: str, norm: bool | None = None) -> None:
+        self.name = name
+        self.norm = norm
         self.parameters = DataFrame(
             columns=["initial", "pmin", "pmax", "vary", "name", "dist"]
         )
 
+    @property
+    def _name(self) -> str:
+        return self.__class__.__name__
+
+    @property
+    @abstractmethod
+    def nparam(self) -> int:
+        """Number of parameters of the noise model."""
+
+    @abstractmethod
+    def simulate(self, res: Series, p: ArrayLike) -> Series:
+        """Simulate noise from the residual series."""
+
+    @abstractmethod
     def set_init_parameters(self, oseries: Series | None = None) -> None:
-        if oseries is not None:
-            pinit = np.diff(oseries.index.to_numpy()) / Timedelta("1D")
-            pinit = np.median(pinit)
-        else:
-            pinit = 14.0
-        self.parameters.loc["noise_alpha"] = (
-            pinit,
-            1e-5,
-            5000.0,
-            True,
-            "noise",
-            "uniform",
-        )
+        """Set initial noise model parameters."""
 
     @set_parameter
     def _set_initial(self, name: str, value: float) -> None:
@@ -109,11 +111,10 @@ class NoiseModelBase:
 
     def to_dict(self) -> dict:
         """Method to return a dict to store the noise model"""
-        data = {"class": self._name, "norm": self.norm}
-        return data
+        settings = {"class": self._name, "norm": self.norm}
+        return settings
 
-    @staticmethod
-    def weights(res, p) -> int:
+    def weights(self, res: Series, p: ArrayLike) -> Series | int:
         return 1
 
 
@@ -122,6 +123,8 @@ class ArNoiseModel(NoiseModelBase):
 
     Parameters
     ----------
+    name: str, optional
+        Name of the noise model. Default is "noise".
     norm: boolean, optional
         Boolean to indicate whether weights are normalized according to the Von
         Asmuth and Bierkens (2005) paper. Default is True.
@@ -146,16 +149,30 @@ class ArNoiseModel(NoiseModelBase):
     optional.
     """
 
-    _name = "ArNoiseModel"
-
-    def __init__(self, norm: bool = True) -> None:
-        NoiseModelBase.__init__(self)
-        self.norm = norm
-        self.nparam = 1
+    def __init__(self, name: str = "noise", norm: bool = True) -> None:
+        super().__init__(name=name, norm=norm)
         self.set_init_parameters()
 
-    @staticmethod
-    def simulate(res: Series, p: ArrayLike) -> Series:
+    def set_init_parameters(self, oseries: Series | None = None) -> None:
+        if oseries is not None:
+            pinit = np.diff(oseries.index.to_numpy()) / Timedelta("1D")
+            pinit = np.median(pinit)
+        else:
+            pinit = 14.0
+        self.parameters.loc[f"{self.name}_alpha"] = (
+            pinit,
+            1e-5,
+            5000.0,
+            True,
+            self.name,
+            "uniform",
+        )
+
+    @property
+    def nparam(self) -> int:
+        return 1
+
+    def simulate(self, res: Series, p: ArrayLike) -> Series:
         """Simulate noise from the residuals.
 
         Parameters
@@ -257,8 +274,8 @@ class ArNoiseModel(NoiseModelBase):
 
     def to_dict(self) -> dict:
         """Method to return a dict to store the noise model"""
-        data = {"class": self._name, "norm": self.norm}
-        return data
+        settings = super().to_dict()
+        return settings
 
 
 @PastasDeprecationWarning(
@@ -267,7 +284,6 @@ class ArNoiseModel(NoiseModelBase):
 )
 def NoiseModel(*args, **kwargs) -> ArNoiseModel:
     n = ArNoiseModel(*args, **kwargs)
-    n._name = "NoiseModel"
     return n
 
 
@@ -292,33 +308,34 @@ class ArmaNoiseModel(NoiseModelBase):
     irregular time steps yet.
     """
 
-    _name = "ArmaNoiseModel"
-
-    def __init__(self) -> None:
-        NoiseModelBase.__init__(self)
-        self.nparam = 2
+    def __init__(self, name: str = "noise", norm: bool = True) -> None:
+        super().__init__(name=name, norm=norm)
         self.set_init_parameters()
 
-    def set_init_parameters(self, oseries: Series = None) -> None:
+    @property
+    def nparam(self) -> int:
+        return 2
+
+    def set_init_parameters(self, oseries: Series | None = None) -> None:
         if oseries is not None:
             pinit = np.diff(oseries.index.to_numpy()) / Timedelta("1D")
             pinit = np.median(pinit)
         else:
             pinit = 14.0
-        self.parameters.loc["noise_alpha"] = (
+        self.parameters.loc[f"{self.name}_alpha"] = (
             pinit,
             1e-9,
             5000.0,
             True,
-            "noise",
+            self.name,
             "uniform",
         )
-        self.parameters.loc["noise_beta"] = (
+        self.parameters.loc[f"{self.name}_beta"] = (
             1.0,
             -np.inf,
             np.inf,
             True,
-            "noise",
+            self.name,
             "uniform",
         )
 
@@ -354,6 +371,11 @@ class ArmaNoiseModel(NoiseModelBase):
             )
         return a
 
+    def to_dict(self) -> dict:
+        """Method to return a dict to store the noise model"""
+        settings = super().to_dict()
+        return settings
+
 
 @PastasDeprecationWarning(
     version="2.0.0",
@@ -361,5 +383,4 @@ class ArmaNoiseModel(NoiseModelBase):
 )
 def ArmaModel(*args, **kwargs) -> ArmaNoiseModel:
     n = ArmaNoiseModel(*args, **kwargs)
-    n._name = "ArmaModel"
     return n

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -111,8 +111,7 @@ class NoiseModelBase(ABC):
 
     def to_dict(self) -> dict:
         """Method to return a dict to store the noise model"""
-        settings = {"class": self._name, "norm": self.norm}
-        return settings
+        return {"class": self._name, "norm": self.norm}
 
     def weights(self, res: Series, p: ArrayLike) -> Series | int:
         return 1
@@ -274,8 +273,7 @@ class ArNoiseModel(NoiseModelBase):
 
     def to_dict(self) -> dict:
         """Method to return a dict to store the noise model"""
-        settings = super().to_dict()
-        return settings
+        return super().to_dict()
 
 
 @PastasDeprecationWarning(
@@ -373,8 +371,7 @@ class ArmaNoiseModel(NoiseModelBase):
 
     def to_dict(self) -> dict:
         """Method to return a dict to store the noise model"""
-        settings = super().to_dict()
-        return settings
+        return super().to_dict()
 
 
 @PastasDeprecationWarning(


### PR DESCRIPTION
This pull request refactors the noise model base class and its subclasses to use Python's abstract base class (ABC) mechanism, improves parameter handling, and standardizes the interface for noise models in line with StressModels (#1217) and Rfuncs (#1173).