### PR TITLE
Improve verbose series validation

### DIFF
--- a/doc/examples/prepare_timeseries.ipynb
+++ b/doc/examples/prepare_timeseries.ipynb
@@ -1085,14 +1085,6 @@
     "\n",
     "pd.concat([valueskept, duplicates], axis=1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2cf2beb",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/doc/examples/prepare_timeseries.ipynb
+++ b/doc/examples/prepare_timeseries.ipynb
@@ -68,7 +68,6 @@
     "index = pd.date_range(\"2000-01-01\", \"2000-01-10\")\n",
     "series = pd.DataFrame(data=[np.arange(10.0)], index=index)\n",
     "\n",
-    "# Here's error message returned by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },
@@ -101,7 +100,6 @@
     "index = pd.date_range(\"2000-01-01\", \"2000-01-10\")\n",
     "series = pd.Series(data=range(10), index=index, name=\"Stress\")\n",
     "\n",
-    "# Here's error message returned by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },
@@ -136,7 +134,6 @@
    "source": [
     "series = pd.Series(data=np.arange(10.0), index=range(10), name=\"Stress\")\n",
     "\n",
-    "# Here's error message returned by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },
@@ -170,7 +167,6 @@
     "index = pd.to_datetime([\"2000-01-01\", \"2000-01-03\", \"2000-01-02\", \"2000-01-4\"])\n",
     "series = pd.Series(data=np.arange(4.0), index=index, name=\"Stress\")\n",
     "\n",
-    "# Here's error message returned by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },
@@ -204,7 +200,6 @@
     "index = pd.to_datetime([\"2000-01-01\", \"2000-01-02\", \"2000-01-02\", \"2000-01-3\"])\n",
     "series = pd.Series(data=np.arange(4.0), index=index, name=\"Stress\")\n",
     "\n",
-    "# Here's error message returned by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },
@@ -249,7 +244,6 @@
     "series = pd.Series(data=np.arange(10.0), index=index, name=\"Stress\")\n",
     "series.loc[\"2000-01-05\"] = np.nan\n",
     "\n",
-    "# Here's warning message returned by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },
@@ -290,7 +284,6 @@
     "idx0[3] = idx0[3] + pd.to_timedelta(1, \"h\")\n",
     "series = pd.Series(index=idx0, data=np.arange(len(idx0), dtype=float), name=\"Stress\")\n",
     "\n",
-    "# Here's error message return by Pastas\n",
     "ps.validate_stress(series, verbose=True)"
    ]
   },

--- a/doc/examples/prepare_timeseries.ipynb
+++ b/doc/examples/prepare_timeseries.ipynb
@@ -24,6 +24,8 @@
     "\n",
     "import pastas as ps\n",
     "\n",
+    "# we already print the errors (verbose=True), so suppress logging in this notebook\n",
+    "ps.logger.setLevel(\"CRITICAL\")\n",
     "ps.show_versions()"
    ]
   },
@@ -67,7 +69,7 @@
     "series = pd.DataFrame(data=[np.arange(10.0)], index=index)\n",
     "\n",
     "# Here's error message returned by Pastas\n",
-    "# ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -77,7 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "series.iloc[:, 0]  # Simply select the first column"
+    "series = series.iloc[:, 0]  # Simply select the first column\n",
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -99,7 +102,7 @@
     "series = pd.Series(data=range(10), index=index, name=\"Stress\")\n",
     "\n",
     "# Here's error message returned by Pastas\n",
-    "# ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -109,8 +112,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Here is a possible fix to this issue\n",
-    "series = series.astype(float)"
+    "# Here are possible fixes to this issue\n",
+    "series = series.astype(float)\n",
+    "series = pd.to_numeric(series, errors=\"coerce\", downcast=\"float\")\n",
+    "\n",
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -131,7 +137,7 @@
     "series = pd.Series(data=np.arange(10.0), index=range(10), name=\"Stress\")\n",
     "\n",
     "# Here's error message returned by Pastas\n",
-    "# ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -143,7 +149,7 @@
    "source": [
     "# Here is a possible fix to this issue\n",
     "series.index = pd.to_datetime(series.index)\n",
-    "ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -165,7 +171,7 @@
     "series = pd.Series(data=np.arange(4.0), index=index, name=\"Stress\")\n",
     "\n",
     "# Here's error message returned by Pastas\n",
-    "ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -199,7 +205,7 @@
     "series = pd.Series(data=np.arange(4.0), index=index, name=\"Stress\")\n",
     "\n",
     "# Here's error message returned by Pastas\n",
-    "ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -220,7 +226,16 @@
    "id": "b52c1724",
    "metadata": {},
    "source": [
-    "### f. If the time series has nan-values"
+    "### f. If the time series has nan-values\n",
+    "\n",
+    "Note that Pastas can deal with NaN values, based on the time series settings that are\n",
+    "provided. For observation time series (oseries) the default behavior is to drop the NaN\n",
+    "values. For stresses the behavior is dependent on the type of stress. For example, for\n",
+    "precipitation NaN values are filled with 0.0. This behavior is controlled through the\n",
+    "StressModel settings (see `ps.rcParams[\"timeseries\"]`). \n",
+    "\n",
+    "Even though Pastas can deal with NaNs it is recommended to pre-process your own time\n",
+    "series, so you know exactly how your time series are processed."
    ]
   },
   {
@@ -235,7 +250,7 @@
     "series.loc[\"2000-01-05\"] = np.nan\n",
     "\n",
     "# Here's warning message returned by Pastas\n",
-    "ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -276,7 +291,7 @@
     "series = pd.Series(index=idx0, data=np.arange(len(idx0), dtype=float), name=\"Stress\")\n",
     "\n",
     "# Here's error message return by Pastas\n",
-    "ps.validate_stress(series)"
+    "ps.validate_stress(series, verbose=True)"
    ]
   },
   {
@@ -1070,11 +1085,19 @@
     "\n",
     "pd.concat([valueskept, duplicates], axis=1)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2cf2beb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pastas",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1088,7 +1111,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -850,7 +850,12 @@ def _validate_series(
             # helpful specific message for multi-column DataFrames
             msg = "DataFrame with multiple columns. Please select one."
             logger.error(msg)
-            raise ValueError(msg)
+            if verbose:
+                print("❌ " + msg)
+                check = False
+                return check
+            else:
+                raise ValueError(msg)
 
     if isinstance(series, TimeSeries):
         series = series.series
@@ -872,7 +877,7 @@ def _validate_series(
     # 1. Make sure the values are float
     if not pd.api.types.is_float_dtype(series):
         msg = (
-            f"The dtype of the values of the series "
+            "The dtype of the values of the series "
             f"'{name}' is not float, but {series.dtype}."
         )
         logger.error(msg)
@@ -904,8 +909,8 @@ def _validate_series(
         if isinstance(series.index.dtype, pd.DatetimeTZDtype):
             msg = (
                 f"The index of series '{name}' is timezone aware. Please "
-                f"convert the series to timezone naive. Try using "
-                f"`series.index = series.index.tz_localize(None)`."
+                "convert the series to timezone naive. Try using "
+                "`series.index = series.index.tz_localize(None)`."
             )
         else:
             msg = (
@@ -925,7 +930,7 @@ def _validate_series(
     if series.index.hasnans:
         msg = (
             f"The index of series '{name}' contains NaNs/NaTs. "
-            f"Try to remove these with `series.loc[series.index.dropna()]`."
+            "Try to remove these with `series.loc[series.index.dropna()]`."
         )
         logger.error(msg)
         if verbose:
@@ -940,7 +945,7 @@ def _validate_series(
     if not series.index.is_monotonic_increasing:
         msg = (
             f"The datetimes in the index of series '{name}' are not monotonically "
-            f"increasing. Try to use `series.sort_index()` to fix it."
+            "increasing. Try to use `series.sort_index()` to fix it."
         )
         logger.error(msg)
         if verbose:
@@ -955,8 +960,8 @@ def _validate_series(
     if not series.index.is_unique:
         msg = (
             f"Duplicate indices were found in the series '{name}'. Try and fix by"
-            f" `grouped = series.groupby(level=0); series = grouped.mean()` "
-            f"or `series = series.loc[~series.index.duplicated(keep='first/last')].`"
+            " `grouped = series.groupby(level=0); series = grouped.mean()` "
+            "or `series = series.loc[~series.index.duplicated(keep='first/last')].`"
         )
         logger.error(msg)
         if verbose:
@@ -971,8 +976,8 @@ def _validate_series(
     if series.hasnans:
         msg = (
             f"The series '{name}' has nan-values. Pastas will use the `fill_nan` "
-            f"from the StressModel's settings (rcParams) parsed to the TimeSeries"
-            f" settings to fill up the nan-values."
+            "from the StressModel's settings (rcParams) parsed to the TimeSeries"
+            " settings to fill up the nan-values."
         )
         logger.warning(msg)
         if verbose:
@@ -983,11 +988,27 @@ def _validate_series(
 
     # 8. Make sure the time series has equidistant time steps
     if equidistant:
-        if not pd.infer_freq(series.index):
+        try:
+            inferred_freq = pd.infer_freq(series.index)
+            if not inferred_freq:
+                msg = (
+                    f"The frequency of the index of time series '{name}' could not be "
+                    "inferred. This indicates that there are gaps or duplicates in "
+                    "your time series. Please resample your time series to an "
+                    "equidistant time step."
+                )
+                logger.error(msg)
+                if verbose:
+                    print("❌ " + msg)
+                    check = False
+                else:
+                    raise ValueError(msg)
+            elif verbose:
+                print("✅ series has equidistant time steps.")
+        except TypeError:
             msg = (
                 f"The frequency of the index of time series '{name}' could not be "
-                f"inferred. This indicates that there are gaps in your time series."
-                f" Please resample your time series to an equidistant time step."
+                "inferred. Unable to check for equidistant time steps."
             )
             logger.error(msg)
             if verbose:
@@ -995,8 +1016,6 @@ def _validate_series(
                 check = False
             else:
                 raise ValueError(msg)
-        elif verbose:
-            print("✅ series has equidistant time steps.")
 
     # If all checks are passed, return True
     return check

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -972,7 +972,7 @@ def _validate_series(
     elif verbose:
         print("✅ series index has no duplicate indices.")
 
-    # 7. Check if the time series nan-values
+    # 7. Check if the time series has nan-values
     if series.hasnans:
         msg = (
             f"The series '{name}' has nan-values. Pastas will use the `fill_nan` "


### PR DESCRIPTION
When verbose=True the behavior of `_validate_series` was a bit inconsistent. Depending on the type of error the function either prints the outcomes of all checks, or raises an error. This PR attempts to avoid raising when verbose=True, and attempts to print the validation results to screen. Using `verbose=True` makes the notebook about preparing timeseries much easier to read in my opinion. 

Improve `_validate_series` when verbose=True:
- when verbose, we want to print all errors, and try to avoid raising errors
- shortcut return when series is DataFrame
- add support for failing equidistant check because index is not datetime etc. Instead of raising, print a more vague error message

Improve notebook
- use verbose everywhere and uncomment validate_series calls
- improve suggested solution for dtype not float
- add info that pastas supports NaNs to to example notebook

# Checklist before PR can be merged:
- [ ] closes issue #xxxx
- [x] is documented
- [x] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [x] type hints
- [x] tests added or expanded
- [x] remove output for all notebooks with changes
- [x] example notebook (for new features)