### PR TITLE
Improve parnames tt

### DIFF
--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -118,8 +118,35 @@ def _load_model(data: dict) -> Model:
         sm = _load_stressmodel(smdata, data)
         ml.add_stressmodel(sm)
 
+    file_parameters = data["parameters"]
     # Add transform
     if "transform" in data.keys():
+        if data["transform"]["class"] == "ThresholdTransform":
+            # the parameters of ThresholdTransform were renamed from 1 and 2 to d and f in pastas 2.0.0,
+            # so we need to check if the old parameter names are present and rename them to the new ones
+            old_param_name = f"{data['transform']['name']}_1"
+            if old_param_name in file_parameters.index:
+                new_param_name = f"{data['transform']['name']}_d"
+                logger.warning(
+                    "Renaming parameter %s to %s to match the naming convention of ThresholdTransform.",
+                    old_param_name,
+                    new_param_name,
+                )
+
+                file_parameters.rename(
+                    index={old_param_name: new_param_name}, inplace=True
+                )
+            old_param_name = f"{data['transform']['name']}_2"
+            if old_param_name in file_parameters.index:
+                new_param_name = f"{data['transform']['name']}_f"
+                logger.warning(
+                    "Renaming parameter %s to %s to match the naming convention of ThresholdTransform.",
+                    old_param_name,
+                    new_param_name,
+                )
+                file_parameters.rename(
+                    index={old_param_name: new_param_name}, inplace=True
+                )
         transform = getattr(ps.transform, data["transform"].pop("class"))
         transform = transform(**data["transform"])
         ml.add_transform(transform)

--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -118,14 +118,13 @@ def _load_model(data: dict) -> Model:
         sm = _load_stressmodel(smdata, data)
         ml.add_stressmodel(sm)
 
-    file_parameters = data["parameters"]
     # Add transform
     if "transform" in data.keys():
         if data["transform"]["class"] == "ThresholdTransform":
             # the parameters of ThresholdTransform were renamed from 1 and 2 to d and f in pastas 2.0.0,
             # so we need to check if the old parameter names are present and rename them to the new ones
             old_param_name = f"{data['transform']['name']}_1"
-            if old_param_name in file_parameters.index:
+            if old_param_name in data["parameters"].index:
                 new_param_name = f"{data['transform']['name']}_d"
                 logger.warning(
                     "Renaming parameter %s to %s to match the naming convention of ThresholdTransform.",
@@ -133,18 +132,18 @@ def _load_model(data: dict) -> Model:
                     new_param_name,
                 )
 
-                file_parameters.rename(
+                data["parameters"].rename(
                     index={old_param_name: new_param_name}, inplace=True
                 )
             old_param_name = f"{data['transform']['name']}_2"
-            if old_param_name in file_parameters.index:
+            if old_param_name in data["parameters"].index:
                 new_param_name = f"{data['transform']['name']}_f"
                 logger.warning(
                     "Renaming parameter %s to %s to match the naming convention of ThresholdTransform.",
                     old_param_name,
                     new_param_name,
                 )
-                file_parameters.rename(
+                data["parameters"].rename(
                     index={old_param_name: new_param_name}, inplace=True
                 )
         transform = getattr(ps.transform, data["transform"].pop("class"))

--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -123,29 +123,24 @@ def _load_model(data: dict) -> Model:
         if data["transform"]["class"] == "ThresholdTransform":
             # the parameters of ThresholdTransform were renamed from 1 and 2 to d and f in pastas 2.0.0,
             # so we need to check if the old parameter names are present and rename them to the new ones
-            old_param_name = f"{data['transform']['name']}_1"
-            if old_param_name in data["parameters"].index:
-                new_param_name = f"{data['transform']['name']}_d"
+            # TODO: remove this check if pas files < 2.0 are no longer supported
+            transform_name = data["transform"]["name"]
+            if (
+                f"{transform_name}_1" in data["parameters"].index
+                or f"{transform_name}_2" in data["parameters"].index
+            ):
+                rename_map = {
+                    f"{transform_name}_1": f"{transform_name}_d",
+                    f"{transform_name}_2": f"{transform_name}_f",
+                }
                 logger.warning(
-                    "Renaming parameter %s to %s to match the naming convention of ThresholdTransform.",
-                    old_param_name,
-                    new_param_name,
+                    "Renaming ThresholdTransform parameters to Pastas 2.0 naming convention: %s",
+                    ", ".join(
+                        f"{old_name} -> {new_name}"
+                        for old_name, new_name in rename_map.items()
+                    ),
                 )
-
-                data["parameters"].rename(
-                    index={old_param_name: new_param_name}, inplace=True
-                )
-            old_param_name = f"{data['transform']['name']}_2"
-            if old_param_name in data["parameters"].index:
-                new_param_name = f"{data['transform']['name']}_f"
-                logger.warning(
-                    "Renaming parameter %s to %s to match the naming convention of ThresholdTransform.",
-                    old_param_name,
-                    new_param_name,
-                )
-                data["parameters"].rename(
-                    index={old_param_name: new_param_name}, inplace=True
-                )
+                data["parameters"] = data["parameters"].rename(index=rename_map)
         transform = getattr(ps.transform, data["transform"].pop("class"))
         transform = transform(**data["transform"])
         ml.add_transform(transform)

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -50,7 +50,7 @@ class ThresholdTransform:
         value: float = np.nan,
         vmin: float = np.nan,
         vmax: float = np.nan,
-        name: str = "threshold",
+        name: str = "transform",
         nparam: int = 2,
     ) -> None:
         self.value = value

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -81,7 +81,7 @@ class ThresholdTransform:
         self.set_init_parameters()
 
     def set_init_parameters(self) -> None:
-        self.parameters.loc[self.name + "_1"] = (
+        self.parameters.loc[self.name + "_d"] = (
             self.value,
             self.vmin,
             self.vmax,
@@ -89,7 +89,7 @@ class ThresholdTransform:
             self.name,
         )
         if self.nparam == 2:
-            self.parameters.loc[self.name + "_2"] = (0.5, 0.0, 1.0, True, self.name)
+            self.parameters.loc[self.name + "_f"] = (0.5, 0.0, 1.0, True, self.name)
 
     @set_parameter
     def _set_initial(self, name: str, value: float) -> None:


### PR DESCRIPTION
# Short description

This PR implements the change proposed in #1231.

This pull request makes minor adjustments to the `pastas/transform.py` file, primarily renaming parameter identifiers and default names for clarity and consistency.

Parameter and naming updates:

* Changed the default `name` argument in the class initializer from `"threshold"` to `"transform"` to better reflect its purpose.
* Renamed parameter keys in `set_init_parameters` from `"_1"` and `"_2"` to `"_d"` and `"_f"` respectively, for improved clarity.

# Checklist before PR can be merged:
- [ ] closes issue #1231
- [ ] is documented
- [ ] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [ ] type hints
- [ ] tests added or expanded
- [ ] remove output for all notebooks with changes
- [ ] example notebook (for new features)