### PR TITLE
Make sure pastas can be imported without numba

### DIFF
--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -8,13 +8,17 @@ time steps often observed in hydrological time series.
 from logging import getLogger
 
 import numpy as np
-from numba import prange
 from pandas import DataFrame, DatetimeIndex, Index, Series, Timedelta, to_timedelta
 from scipy.stats import norm
 
 from pastas.typing import ArrayLike
 
 from ..decorators import njit
+
+try:
+    from numba import prange
+except ImportError:
+    prange = range
 
 logger = getLogger(__name__)
 

--- a/pastas/version.py
+++ b/pastas/version.py
@@ -43,7 +43,11 @@ def get_versions(optional: bool = False) -> dict[str, str]:
         "numba",
     )
     for module in required_dependencies:
-        version_dict[module] = metadata.version(module)
+        try:
+            import_module(module)
+            version_dict[module] = metadata.version(module)
+        except ImportError:
+            version_dict[module] = "Not Installed"
 
     if optional:
         optional_dependencies = (


### PR DESCRIPTION
# Short description
This PR makes sure pastas can still be imported in an environment where numba is not installed. For example, in a qgis-plugin, we can ship pastas together with the plugin, and it would still function without numba. 

# Checklist before PR can be merged:
- [x] closes issue #1184