### PR TITLE
Update tests for coverage via gist

### DIFF
--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -96,7 +96,7 @@ jobs:
         uses: Schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ env.BADGE_GIST_COVERAGE_TOKEN }}
-          gistID: "{GIST_TAG_HERE}"
+          gistID: "{02bcb92e1d487ffc9143752296b8db72}"
           filename: coverage.json
           label: coverage
           message: ${{ steps.coverage.outputs.coverage }}%

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -96,7 +96,7 @@ jobs:
         uses: Schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ env.BADGE_GIST_COVERAGE_TOKEN }}
-          gistID: "a891dd883f258c46826ba657cf9a89cf"
+          gistID: "{GIST_TAG_HERE}"
           filename: coverage.json
           label: coverage
           message: ${{ steps.coverage.outputs.coverage }}%

--- a/.github/workflows/test_unit_pytest.yml
+++ b/.github/workflows/test_unit_pytest.yml
@@ -47,6 +47,7 @@ jobs:
             toxenv: all
             experimental: false
     env:
+      BADGE_GIST_COVERAGE_TOKEN: ${{ secrets.BADGE_GIST_COVERAGE_TOKEN }}
       CI_PASFILES: "0" # do not generate pas files for these tests
       # Color Output
       # Rich (pip)
@@ -75,10 +76,27 @@ jobs:
       - name: Test
         run: uv run tox -e ${{ matrix.toxenv }} --skip-pkg-install
 
-      - name: Run codacy-coverage-reporter
-        if: ${{ matrix.toxenv == 'all' && github.repository == 'pastas/pastas' &&
-          success() }}
-        uses: codacy/codacy-coverage-reporter-action@master
+      - name: Export Coverage Percent
+        if: matrix.toxenv == 'all'
+        id: coverage
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          data = json.loads(Path("coverage.json").read_text())
+          coverage = data["totals"]["percent_covered_display"]
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as fh:
+              fh.write(f"coverage={coverage}\n")
+          PY
+
+      - name: Update Coverage Badge
+        if: matrix.toxenv == 'all' && github.event_name == 'push' && env.BADGE_GIST_COVERAGE_TOKEN != ''
+        uses: Schneegans/dynamic-badges-action@v1.7.0
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.xml
+          auth: ${{ env.BADGE_GIST_COVERAGE_TOKEN }}
+          gistID: "a891dd883f258c46826ba657cf9a89cf"
+          filename: coverage.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.coverage }}%

--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,29 @@
-
-*.xml
+# Python files
 *.iml
 *.pyc
 *.so
-*.coverage*
 *.amlignore*
 *.DS_Store
-
 pastas.egg-info
 pastas/gui/settings
 
-examples/notebooks/.ipynb_checkpoints/
-gui/settings
-build
-dist
+# Test and coverage files
 .tox
+tests/data/pas_files_*/
+coverage.json
+*.coverage*
+*.xml
 
+# IDE settings
 .idea/.name
 .cache/v/cache/lastfailed
 *.log
-
-**/*.ipynb_checkpoints/
-
 .vscode/*
-
-# Spyder project settings
 .spyderproject
 .spyproject
 .pylint.d/
 
+# Docs
 /doc/api/generated/
 doc/about/publications.bib
 doc/about/references.bib
@@ -36,5 +31,8 @@ doc/about/references.bib
 *.nbi
 *.pdf
 *.lock
-
-tests/data/pas_files_*/
+examples/notebooks/.ipynb_checkpoints/
+**/*.ipynb_checkpoints/
+gui/settings/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 [![image](https://img.shields.io/pypi/dm/pastas)](https://pypi.org/project/pastas/)
 [![image](https://zenodo.org/badge/DOI/10.5281/zenodo.1465866.svg)](https://doi.org/10.5281/zenodo.1465866)
 
-[![image](https://app.codacy.com/project/badge/Grade/952f41c453854064ba0ee1fa0a0b4434)](https://app.codacy.com/gh/pastas/pastas/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![image](https://api.codacy.com/project/badge/Coverage/952f41c453854064ba0ee1fa0a0b4434)](https://app.codacy.com/gh/pastas/pastas/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage9)
+[![image](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/pastas/{GIST_TAG_HERE}/raw/coverage.json&color=green)](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml)
 [![image](https://readthedocs.org/projects/pastas/badge/?version=stable)](https://pastas.readthedocs.io/)
 [<img src="https://github.com/codespaces/badge.svg" height="20">](https://codespaces.new/pastas/pastas?quickstart=1)
 [![image](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml/badge.svg?branch=master)](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![image](https://img.shields.io/pypi/dm/pastas)](https://pypi.org/project/pastas/)
 [![image](https://zenodo.org/badge/DOI/10.5281/zenodo.1465866.svg)](https://doi.org/10.5281/zenodo.1465866)
 
-[![image](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/pastas/{GIST_TAG_HERE}/raw/coverage.json&color=green)](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml)
+[![image](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/pastas/{02bcb92e1d487ffc9143752296b8db72}/raw/coverage.json&color=green)](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml)
 [![image](https://readthedocs.org/projects/pastas/badge/?version=stable)](https://pastas.readthedocs.io/)
 [<img src="https://github.com/codespaces/badge.svg" height="20">](https://codespaces.new/pastas/pastas?quickstart=1)
 [![image](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml/badge.svg?branch=master)](https://github.com/pastas/pastas/actions/workflows/test_unit_pytest.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ commands = [
 ]
 
 [tool.tox.env.all]
-description = "run all unit tests (including Notebooks) and obtain coverage"
+description = "run all unit tests and notebooks"
 extras = ["ci"]
 commands = [
     [
@@ -146,7 +146,7 @@ commands = [
     ],
     [
         "coverage",
-        "xml",
+        "json",
     ],
 ]
 


### PR DESCRIPTION
# Short description
Codacy is already failing on the dev branch so this gets rid of it once and for all.

I don't have the rights to set this up internally on pastas. So, @raoulcollenteur or @dbrakenhoff, you have to follow the instructions: https://github.com/Schneegans/dynamic-badges-action to setup the gist. And commit the tag to the README.md. Then this should work.

- [x] closes issue #1241 