### PR TITLE
Fix issue 1268: make sure unit of DatetimeIndex is correct before interpolating in pandas 3.x

### DIFF
--- a/pastas/check.py
+++ b/pastas/check.py
@@ -67,6 +67,7 @@ from matplotlib.colors import rgb2hex
 from pandas import DataFrame, Series, Timedelta, concat
 
 from pastas.stats import tests as diagnostic_tests
+from pastas.timeseries_utils import _index_to_int64
 from pastas.typing import Model
 
 logger = logging.getLogger(__name__)
@@ -741,9 +742,9 @@ def correlation_sim_vs_res(ml: Model, threshold: float = 0.2):
     sim = Series(
         index=res.index,
         data=np.interp(
-            res.index.view("int64"),
-            sim.index.view("int64"),
-            sim.to_numpy(copy=True),
+            _index_to_int64(res.index),
+            _index_to_int64(sim.index),
+            sim.to_numpy(),
         ),
     )
     label = f"|corr(sim, res)| < {threshold}"

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -53,6 +53,7 @@ from pastas.timeseries_utils import (
     _get_dt,
     _get_sim_index,
     _get_time_offset,
+    _index_to_int64,
     _parse_warmup,
 )
 from pastas.transform import ThresholdTransform
@@ -606,9 +607,9 @@ class Model:
         if self._interpolate_simulation:
             # interpolate simulation to times of observations
             sim_interpolated = np.interp(
-                obs.index.view("int64"),
-                sim.index.view("int64"),
-                sim.to_numpy(copy=True),
+                _index_to_int64(obs.index),
+                _index_to_int64(sim.index),
+                sim.to_numpy(),
             )
         else:
             # All the observation indexes are in the simulation

--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -18,6 +18,7 @@ This returns a Series containing the statistics::
 from numpy import interp, nan
 from pandas import DataFrame, Series, Timestamp
 
+from pastas.timeseries_utils import _index_to_int64
 from pastas.typing import Model
 
 from .decorators import model_tmin_tmax
@@ -430,9 +431,9 @@ class Statistics:
             # interpolate simulation to times of observations
             sim_interpolated = Series(
                 interp(
-                    obs.index.view("int64"),
-                    sim.index.view("int64"),
-                    sim.to_numpy(copy=True),
+                    _index_to_int64(obs.index),
+                    _index_to_int64(sim.index),
+                    sim.to_numpy(),
                 ),
                 index=obs.index,
             )

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -198,8 +198,8 @@ class ArNoiseModel(NoiseModelBase):
             Series of the noise.
         """
         alpha = p[0]
-        odelt = np.diff(res.index.to_numpy(copy=True)) / Timedelta("1D")
-        resv = res.to_numpy(copy=True)
+        odelt = np.diff(res.index.to_numpy()) / Timedelta("1D")
+        resv = res.to_numpy()
         v = np.append(resv[0], resv[1:] - np.exp(-odelt / alpha) * resv[:-1])
         return Series(data=v, index=res.index, name="Noise")
 

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -23,6 +23,7 @@ from pastas.plotting.plotutil import (
     plot_series_with_gaps,
     share_xaxes,
 )
+from pastas.timeseries_utils import _index_to_int64
 from pastas.typing import Axes, Figure, Model, StressModel
 
 logger = logging.getLogger(__name__)
@@ -727,8 +728,8 @@ class Plotting:
 
         if self.ml._interpolate_simulation:
             sim_interpolated = np.interp(
-                res.index.view("int64"),
-                sim.index.view("int64"),
+                _index_to_int64(res.index),
+                _index_to_int64(sim.index),
                 sim.values,
             )
             sim = Series(index=res.index, data=sim_interpolated)

--- a/pastas/plotting/plotly.py
+++ b/pastas/plotting/plotly.py
@@ -22,6 +22,7 @@ from pastas.plotting.plotutil import (
     _table_formatter_stderr,
 )
 from pastas.rfunc import HantushWellModel
+from pastas.timeseries_utils import _index_to_int64
 from pastas.stats import acf
 
 
@@ -537,9 +538,9 @@ class Plotly:
 
         if self._model._interpolate_simulation:
             sim_interpolated = np.interp(
-                series.index.view("int64"),
-                sim.index.view("int64"),
-                sim.to_numpy(copy=True),
+                _index_to_int64(series.index),
+                _index_to_int64(sim.index),
+                sim.to_numpy(),
             )
             sim = pd.Series(index=series.index, data=sim_interpolated)
 

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -317,7 +317,7 @@ def _preprocess(
     if series is None:
         raise TypeError("_preprocess() missing required argument: 'series'")
 
-    x_idx = series.index.to_series().diff().dropna().to_numpy(copy=True)
+    x_idx = series.index.to_series().diff().dropna().to_numpy()
 
     dt = x_idx / Timedelta(1, "D")
     dt_mu = dt[dt < max_gap].mean()  # Deal with big gaps if present
@@ -325,7 +325,7 @@ def _preprocess(
     t = dt.cumsum()
 
     # Normalize the values and create numpy arrays
-    x_vals = series.to_numpy(copy=True)  # pandas 3.0: ensure writeable array
+    x_vals = series.to_numpy()  # pandas 3.0: ensure writeable array
     x = (x_vals - x_vals.mean()) / x_vals.std()
 
     return x, t, dt_mu
@@ -525,7 +525,7 @@ def var(
         raise TypeError("var() missing required argument: 'series'")
 
     w = _get_weights(series, weighted=weighted, max_gap=max_gap)
-    x = series.to_numpy(copy=True)
+    x = series.to_numpy()
     mu = np.average(x, weights=w)
     sigma = np.sum(x.size / (x.size - 1) * w * (x - mu) ** 2)
     return sigma
@@ -612,7 +612,7 @@ def moment(series: Series | None = None, order: int = 0, **kwargs) -> float:
             "The index of the series must be numeric (float or int) representing "
             "time steps, not a DatetimeIndex. Use a numeric index instead."
         )
-    return float(np.sum((index**order) * series.to_numpy(copy=True)))
+    return float(np.sum((index**order) * series.to_numpy()))
 
 
 # Helper functions
@@ -655,7 +655,7 @@ def _get_weights(
     if series is None:
         raise TypeError("_get_weights() missing required argument: 'series'")
 
-    x_index = series.index.to_numpy(copy=True)
+    x_index = series.index.to_numpy()
     if weighted:
         w = np.append(0.0, np.diff(x_index) / Timedelta("1D"))
         w[w > max_gap] = max_gap

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -135,7 +135,7 @@ class StressModelBase(ABC):
     @PastasDeprecationWarning(
         version="2.0.0",
         reason=(
-            "The get_nsplit methods is deprecated. To inspect the number of available split"
+            "The get_nsplit method is deprecated. To inspect the number of available split"
             " options, use the property `nsplit` instead, e.g., `stressmodel.nsplit`."
         ),
     )
@@ -2035,13 +2035,13 @@ class RechargeModel(StressModelBase):
         self.update_stress(tmin=tmin, tmax=tmax, freq=freq)
 
         if istress is None:
-            prec = self.prec.series.to_numpy(copy=True)
-            evap = self.evap.series.to_numpy(copy=True)
+            prec = self.prec.series.to_numpy()
+            evap = self.evap.series.to_numpy()
             temp = None
             if self.temp is not None:
-                temp = self.temp.series.to_numpy(copy=True)
+                temp = self.temp.series.to_numpy()
             if p is None:
-                p = self.parameters.loc[:, "initial"].to_numpy(copy=True)
+                p = self.parameters.loc[:, "initial"].to_numpy()
             stress = self.recharge.simulate(
                 prec=prec, evap=evap, p=p[-self.recharge.nparam :], **{"temp": temp}
             )
@@ -2113,7 +2113,7 @@ class RechargeModel(StressModelBase):
 
         """
         if p is None:
-            p = self.parameters.initial.to_numpy(copy=True)
+            p = self.parameters.initial.to_numpy()
 
         prec = self.get_stress(tmin=tmin, tmax=tmax, freq=freq, istress=0).to_numpy(
             copy=True
@@ -2151,11 +2151,10 @@ class RechargeModel(StressModelBase):
             An array of the parameters of the stressmodel.
 
         """
-        p = (
-            self.parameters.initial.to_numpy(copy=True)
-            if model is None
-            else model.get_parameters(self.name).copy()
-        )
+        if model is None:
+            p = self.parameters.initial.to_numpy(copy=True)
+        else:
+            p = model.get_parameters(self.name).copy()
 
         if istress is not None and isinstance(self.recharge, Linear):
             if istress == 0:
@@ -2368,7 +2367,7 @@ class TarsoModel(RechargeModel):
     ) -> Series:
         _ = istress  # istress is not used for TarsoModel
         stress = self.get_stress(p=p, tmin=tmin, tmax=tmax, freq=freq)
-        h = self.tarso(p[: -self.recharge.nparam], stress.to_numpy(copy=True), dt)
+        h = self.tarso(p[: -self.recharge.nparam], stress.to_numpy(), dt)
         # Strip imaginary part when not doing complex-step Jacobian
         if not np.iscomplexobj(p):
             h = h.real

--- a/pastas/timeseries.py
+++ b/pastas/timeseries.py
@@ -140,6 +140,12 @@ class TimeSeries:
                 metadata = series.metadata
             series = series.series
 
+        # for pandas 3.0, make sure the unit of the datetime index is in microseconds
+        # as this is the default for pandas 3.0 (and therefore used for the simulation)
+        # for pandas 2.x, the unit is allways nanoseconds, and cannot be changed
+        if hasattr(series.index, "as_unit"):  # pandas >= 3.0
+            series.index = series.index.as_unit("us")
+
         # Store a copy of the original series
         self._series_original = series.copy()  # copy of the original series
         self._series = None

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -479,10 +479,10 @@ def timestep_weighted_resample(
         # set values after the end of the original series to NaN
         s_new[s_new.index > series.index[-1]] = np.nan
     else:
-        t_e = series.index.view("int64")
+        t_e = _index_to_int64(series.index)
         t_s = t_e - dt
         v = series.values
-        t_new = index.view("int64")
+        t_new = _index_to_int64(index)
         v_new = _ts_resample_slow(t_s, t_e, v, t_new)
         s_new = Series(v_new, index)
 
@@ -490,7 +490,7 @@ def timestep_weighted_resample(
 
 
 def _get_dt_array(index):
-    dt = np.diff(index.view("int64"))
+    dt = np.diff(_index_to_int64(index))
     # assume the first value has an equal timestep as the second value
     dt = np.hstack((dt[0], dt))
     return dt
@@ -703,23 +703,23 @@ def get_equidistant_series_nearest(
 
     # get linear interpolated index from original series
     fl = interpolate.interp1d(
-        series.index.view("int64"),
+        _index_to_int64(series.index),
         np.arange(0, series.index.size),
         kind="linear",
         bounds_error=False,
         fill_value="extrapolate",
     )
-    ind_linear = fl(idx.view("int64"))
+    ind_linear = fl(_index_to_int64(idx))
 
     # get the nearest index from original series
     f = interpolate.interp1d(
-        series.index.view("int64"),
+        _index_to_int64(series.index),
         np.arange(0, series.index.size),
         kind="nearest",
         bounds_error=False,
         fill_value="extrapolate",
     )
-    ind = f(idx.view("int64")).astype(int)
+    ind = f(_index_to_int64(idx)).astype(int)
 
     # create a new equidistant series
     s = Series(index=idx, data=np.nan)
@@ -898,3 +898,12 @@ def resample(
 
     """
     return series.resample(freq, closed=closed, label=label, **kwargs)
+
+
+def _index_to_int64(index: DatetimeIndex) -> np.ndarray:
+    """Convert a pandas index to int64 representation."""
+    if hasattr(index, "as_unit"):  # pandas >= 3.0
+        # In pandas 3.0, the default resolution for newly created datetime-like objects
+        # is datetime64[us] (microseconds)
+        index = index.as_unit("us")
+    return index.view("int64")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,9 @@ def ml_with_interpolation(
     head: pd.Series, prec: pd.Series, evap: pd.Series
 ) -> ps.Model:
     """Return a model with a recharge (rain) model with some offset added to the head-series."""
-    ml = ps.Model(head + pd.Timedelta(hours=12), name="recharge_model")
+    head_offset = head.copy()
+    head_offset.index = head_offset.index + pd.Timedelta(hours=12)
+    ml = ps.Model(head_offset, name="recharge_model")
     sm = ps.RechargeModel(prec, evap, name="rch", rfunc=ps.Exponential())
     ml.add_stressmodel(sm)
     return ml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,17 @@ def ml_recharge(head: pd.Series, prec: pd.Series, evap: pd.Series) -> ps.Model:
 
 
 @pytest.fixture
+def ml_with_interpolation(
+    head: pd.Series, prec: pd.Series, evap: pd.Series
+) -> ps.Model:
+    """Return a model with a recharge (rain) model with some offset added to the head-series."""
+    ml = ps.Model(head + pd.Timedelta(hours=12), name="recharge_model")
+    sm = ps.RechargeModel(prec, evap, name="rch", rfunc=ps.Exponential())
+    ml.add_stressmodel(sm)
+    return ml
+
+
+@pytest.fixture
 def ml_solved(ml_recharge: ps.Model) -> ps.Model:
     """Return a model with a recharge (rain) model."""
     ml = ml_recharge.copy()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -443,12 +443,23 @@ class TestModelParameters:
 class TestModelSolving:
     """Test model solving."""
 
-    def test_solve(self, ml_solved: ps.Model) -> None:
+    # Parameterize the test with the string names of the fixtures you want to use
+    @pytest.mark.parametrize("model_name", ["ml_recharge", "ml_with_interpolation"])
+    def test_solve(self, model_name: str, request: pytest.FixtureRequest) -> None:
         """Test solving the model."""
-        ml_solved.solve(report=False)
+        ml = request.getfixturevalue(model_name)
+        ml.solve(report=False)
 
-        assert ml_solved.solver is not None
-        assert ml_solved.parameters["optimal"].notna().any()
+        assert ml.solver is not None
+        assert ml.parameters["optimal"].notna().any()
+
+        # make sure all parameters that can vary have changed from their initial values
+        for param in ml.parameters.index:
+            if ml.parameters.at[param, "vary"]:
+                assert not np.isclose(
+                    ml.parameters.at[param, "optimal"],
+                    ml.parameters.at[param, "initial"],
+                )
 
     def test_solve_with_weights(self, ml_solved: ps.Model) -> None:
         """Test solving with weights."""


### PR DESCRIPTION
# Short description
This PR fixes issue #1268. It makes sure that, wherever an integer representation of the DatetimeIndex is used, that its unit is always the same, and equal to the pandas default (ns for pandas 2.x and us for pandas 3.x). This is done by replacing `index.view("int64")` by  our own small method `_index_to_int64(index)`. In this way, interpolation of the simulation to the observations is always performed correctly.

This PR also removes the unnecessary `copy=True` from `to_numpy` where the resulting numpy array is not modified.

# Checklist before PR can be merged:
- [x] closes issue #1268
- [x] code formatted and linted with [ruff](https://docs.astral.sh/ruff/)
- [x] tests added or expanded