### PR TITLE
Restore "Head" and "Rise" y-labels in results plots

### DIFF
--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -137,7 +137,7 @@ class Plotting:
         all_responses: bool = False,
         adjust_height: bool = True,
         return_warmup: bool = False,
-        add_ylabels: bool = False,
+        add_ylabels: bool = True,
         block_or_step: Literal["block", "step"] = "step",
         stderr: bool = False,
         return_dict: bool = False,
@@ -167,7 +167,7 @@ class Plotting:
         return_warmup: bool, optional
             Show, not return, the warmup-period. Default is False.
         add_ylabels: bool, optional
-            Add ylabels to the subplots. Default is False.
+            Add ylabels to the subplots. Default is True.
         block_or_step: {"block", "step"}, optional
             Plot the block- or step-response on the right. Default is 'step'.
         stderr : bool, optional

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -37,6 +37,16 @@ def test_results(ml_noisemodel: Model) -> None:
     plt.close()
 
 
+def test_results_default_ylabels(ml_noisemodel: Model) -> None:
+    # regression test for https://github.com/pastas/pastas/issues/1271
+    axd = ml_noisemodel.plots.results(return_dict=True)
+    assert axd["sim"].get_ylabel() == "Head"
+    con_keys = [k for k in axd if k.startswith("con_")]
+    assert con_keys
+    assert all(axd[k].get_ylabel() == "Rise" for k in con_keys)
+    plt.close()
+
+
 def test_results_kwargs(ml_noisemodel: Model) -> None:
     _ = ml_noisemodel.plots.results(
         split_contributions=True,


### PR DESCRIPTION
This PR restores the "Head" and "Rise" y-labels in the results plots by changing the default value of the `add_ylabels` parameter to `True` in `Plotting.results`. A regression test has also been added to verify these labels are present by default.

Closes #1271