### PR TITLE
Support the old way to add a stressmodel/noisemodel/transform/constant/solver again

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -130,18 +130,15 @@ def check_argument_model(function: Callable) -> Callable:
 
     @wraps(function)
     def _make_model_component(self, *args, **kwargs):
-        if args:
-            from pastas.model import Model
-
-            ml = args[0]
-            if not isinstance(ml, Model):
-                msg = "Since Pastas 2.0, the first argument of a stress model needs to be a Pastas Model instance to which the stress model is added. Please provide the model is the first argument: %s(model=ml, ...)"
-                logger.error(msg % self._name)
-                raise KeyError(msg % self._name)
-            else:
-                return function(self, *args, **kwargs)
-        else:
+        if "model" in kwargs:
             return function(self, *args, **kwargs)
+        from pastas.model import Model
+
+        if args and isinstance(args[0], Model):
+            return function(self, *args, **kwargs)
+        msg = "From Pastas 2.3, the first argument of %s needs to be a Pastas Model. Please provide the model as the first argument: %s(model=ml, ...)."  # From Pastas 2.3 the workflow with ml.add_xxx() will cease to function.
+        logger.warning(msg % (self._name, self._name))
+        return function(self, None, *args, **kwargs)
 
     return _make_model_component
 

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -225,12 +225,26 @@ class Model:
         )
 
     @PastasDeprecationWarning(
-        version="2.0",
+        version="2.3.0",
         reason="Stressmodels are now added by adding the Pastas Model as the first argument during stressmodel initialization (i.e., ps.Stressmodel(model=ml, *args))",
     )
-    def add_stressmodel(*args, **kwargs):
+    def add_stressmodel(
+        self, stressmodel: StressModel | list[StressModel], replace: bool = True
+    ):
         """Add a stressmodel to the model (Deprecated)."""
-        pass
+        # Method can take multiple stressmodels at once through args
+        if isinstance(stressmodel, list):
+            for sm in stressmodel:
+                self.add_stressmodel(sm)
+        elif (stressmodel.name in self.stressmodels.keys()) and not replace:
+            msg = (
+                "The name for the stressmodel you are trying to add already exists "
+                "for this model. Select another name."
+            )
+            logger.error(msg)
+            raise ValueError(msg)
+        else:
+            self._add_stressmodel(stressmodel)
 
     def _add_stressmodel(self, stressmodel: StressModel) -> None:
         """Add a stressmodel to the main model.
@@ -268,12 +282,12 @@ class Model:
         self._check_stressmodel_compatibility()
 
     @PastasDeprecationWarning(
-        version="2.0",
+        version="2.3.0",
         reason="Constants are now added by adding the Pastas Model as the first argument during initialization (i.e., ps.Constant(model=ml, *args))",
     )
-    def add_constant(*args, **kwargs):
+    def add_constant(self, constant: Constant) -> None:
         """Add a constant to the model (Deprecated)."""
-        pass
+        self._add_constant(constant)
 
     def _add_constant(self, constant: Constant) -> None:
         """Add a Constant to the time series Model.
@@ -289,14 +303,15 @@ class Model:
         self._check_stressmodel_compatibility()
 
     @PastasDeprecationWarning(
-        version="2.0",
+        version="2.3.0",
         reason="Transforms are now added by adding the Pastas Model as the first "
         "argument during Transform initialization (i.e., ps.ThresholdTransform"
         "(model=ml, *args))",
     )
-    def add_transform(*args, **kwargs):
+    def add_transform(self, transform: ThresholdTransform):
         """Add a Transform to the model (Deprecated)."""
-        pass
+        transform.set_model(self)
+        self._add_transform(transform)
 
     def _add_transform(self, transform: ThresholdTransform):
         """Add a Transform to the time series Model.
@@ -315,14 +330,14 @@ class Model:
         self._check_stressmodel_compatibility()
 
     @PastasDeprecationWarning(
-        version="2.0",
+        version="2.3.0",
         reason="Noise models are now added by adding the Pastas Model as the first "
         "argument during noise model initialization (i.e., ps.ArNoiseModel"
         "(model=ml, *args))",
     )
-    def add_noisemodel(*args, **kwargs):
+    def add_noisemodel(self, noisemodel: NoiseModelType) -> None:
         """Add a noisemodel to the model (Deprecated)."""
-        pass
+        self._add_noisemodel(noisemodel)
 
     def _add_noisemodel(self, noisemodel: NoiseModelType) -> None:
         """Add a noisemodel to the time series Model.
@@ -349,14 +364,14 @@ class Model:
         self._parameters = self.get_init_parameters(initial=False)
 
     @PastasDeprecationWarning(
-        version="2.0",
+        version="2.3.0",
         reason="Solvers are now added by adding the Pastas Model as the first "
         "argument during solver initialization (i.e.,  ps.solver.LeastSquares"
         "(model=ml, *args))",
     )
-    def add_solver(*args, **kwargs):
+    def add_solver(self, solver: Solver) -> None:
         """Add a solver to the model (Deprecated)."""
-        pass
+        self._add_solver(solver)
 
     def _add_solver(self, solver: Solver) -> None:
         """Add a solver to the model.
@@ -836,7 +851,7 @@ class Model:
             If None, the solver from `ml.solver` is used. If `solver` and `ml.solver`
             are both None, the default ps.solver.LeastSquares() is used.
 
-            .. deprecated:: 2.0.0
+            .. deprecated:: 2.3.0
                 The solver argument is deprecated in favor of adding a solver using the `ps.solver.LeastSquares(model=ml)` pattern.
 
         report: bool | Literal["full"] | dict, optional
@@ -981,9 +996,13 @@ class Model:
 
         # Check if the solver is provided, deprecated with Pastas 2.0
         if solver is not None:  # add solver if provided
-            msg = "solver argument is deprecated since Pastas 2.0. Please use ps.solver.LeastSquares(ml) pattern instead to add a solver."
-            logger.error(msg)
-            raise KeyError(msg)
+            msg = "solver argument is deprecated and will be removed in Pastas 2.3.0. Please use ps.solver.LeastSquares(ml) pattern instead to add a solver."
+            logger.warning(msg)
+            if self.solver is None or self.solver._name != solver._name:
+                logger.info("Setting solver to `%s`." % solver._name)
+                self.add_solver(solver=solver)
+            else:
+                logger.info("Keeping original solver `%s`." % self.solver._name)
 
         # Add default solver if none is provided
         if self.solver is None:  # add scipy least_squares if no solver provided

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1000,7 +1000,7 @@ class Model:
             logger.warning(msg)
             if self.solver is None or self.solver._name != solver._name:
                 logger.info("Setting solver to `%s`." % solver._name)
-                self.add_solver(solver=solver)
+                self._add_solver(solver=solver)
             else:
                 logger.info("Keeping original solver `%s`." % self.solver._name)
 

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -503,7 +503,8 @@ class StressModel(StressModelBase):
         )
         self.gain_scale_factor = gain_scale_factor
         self.set_init_parameters()
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
     @property
     def stress(self) -> TimeSeries:
@@ -692,7 +693,8 @@ class StepModel(StressModelBase):
         )
         self.tstart = Timestamp(tstart)
         self.set_init_parameters()
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
     @property
     def stresses(self) -> tuple:
@@ -841,7 +843,8 @@ class LinearTrend(StressModelBase):
         self.tstart = tstart
         self.tend = tend
         self.set_init_parameters()
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
     @property
     def stresses(self) -> tuple:
@@ -955,7 +958,8 @@ class Constant(StressModelBase):
         super().__init__(model=model, name=name, tmin=Timestamp.min, tmax=Timestamp.max)
         self.initial = initial
         self.set_init_parameters()
-        self.model._add_constant(self)
+        if self.model is not None:
+            self.model._add_constant(self)
 
     @property
     def stresses(self) -> tuple:
@@ -1164,7 +1168,8 @@ class WellModel(StressModelBase):
 
         self.rfunc.set_distances(self.distances.values)
         self.set_init_parameters()
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
     @property
     def stress(self) -> tuple[TimeSeries, ...]:
@@ -1791,7 +1796,8 @@ class RechargeModel(StressModelBase):
         )
 
         self.set_init_parameters()
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
         # Check if precipitation is likely in mm/d and not m/d. If the maximum
         # value of the annual sums is smaller than 12 (m), the highest annual
@@ -2335,7 +2341,8 @@ class TarsoModel(RechargeModel):
         super().__init__(
             model=model, prec=prec, evap=evap, rfunc=rfunc, name=name, **kwargs
         )
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
     @property
     def nsplit(self) -> int:
@@ -2637,7 +2644,8 @@ class ChangeModel(StressModelBase):
         self.rfunc2 = rfunc2
         self.tchange = Timestamp(tchange)
         self.set_init_parameters()
-        self.model._add_stressmodel(self)
+        if self.model is not None:
+            self.model._add_stressmodel(self)
 
     @property
     def stress(self) -> TimeSeries:

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -64,8 +64,9 @@ class ThresholdTransform:
         self.name = validate_name(name)
         self._nparam = nparam
         self.parameters = DataFrame(columns=["initial", "pmin", "pmax", "vary", "name"])
-        self.model._add_transform(self)
-        self.set_init_parameters()
+        if self.model is not None:
+            self.model._add_transform(self)
+            self.set_init_parameters()
 
     @property
     def nparam(self) -> int:

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -68,6 +68,11 @@ class ThresholdTransform:
             self.model._add_transform(self)
             self.set_init_parameters()
 
+    def set_model(self, ml: Model) -> None:
+        """Set model observations and initialize parameters."""
+        self.model = ml
+        self.set_init_parameters()
+
     @property
     def nparam(self) -> int:
         """Return the number of parameters."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -174,6 +174,20 @@ class TestModelComponents:
         # Check that it was replaced with the new one
         assert ml_solved.stressmodels[first_sm_name].rfunc._name == "Gamma"
 
+    def test_add_stressmodel_indirectly(
+        self, ml_basic: ps.Model, prec: pd.Series
+    ) -> None:
+        """Test adding a stress model using ml.add_stressmodel(), allowed until pastas 2.3."""
+        sm = ps.StressModel(
+            stress=prec,
+            rfunc=ps.Exponential(),
+            name="precipitation",
+        )
+        ml_basic.add_stressmodel(sm)
+
+        assert "precipitation" in ml_basic.stressmodels
+        assert ml_basic.stressmodels["precipitation"] is sm
+
     def test_del_stressmodel(self, ml_solved: ps.Model) -> None:
         """Test deleting a stress model."""
         # Get the first stressmodel name


### PR DESCRIPTION
# Short description
This PR makes sure the changes in PR #1270 are backwards compatible. So a stressmodel/noisemodel/transform/constant/solver can be generated without specifying the Pastas Model as the first argument, and ml.add_stressmodel, ml.add_noisemodel, etc function again. With both functionalities, the user will be shown a warning, that together will inform the user of the new way to add these model elements (by specifying the model as the first argument).

# Checklist before PR can be merged:
- [x] a test is added to test the old way of adding a stressmodel: `test_add_stressmodel_indirectly`