### PR TITLE
docs: fix Anaconda Distribution link from reStructuredText to Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ ml.plots.results()
 To install Pastas, a working version of Python has to be installed on
 your computer. We recommend using [uv](https://docs.astral.sh/uv/) to manage Python
 and your project dependencies. However, you are free to use any Python installation
-method you prefer. The `Anaconda Distribution
-<https://www.anaconda.com/products/distribution>`_ is another popular option.
+method you prefer. The [Anaconda Distribution](https://www.anaconda.com/products/distribution) is another popular option.
 
 ### Stable version
 


### PR DESCRIPTION
## Description
This PR fixes the link syntax for the Anaconda Distribution link in `README.md`.

## Details
The link previously used reStructuredText markup (` `Anaconda Distribution <...>`_`) inside a Markdown file (`README.md`), causing it to render as unformatted raw text. This converts it to standard Markdown link format (`[Anaconda Distribution](...)`).