### PR TITLE
Make deprecations for Pastas 2.0 consistent

### DIFF
--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -12,7 +12,7 @@ from pastas import check, extensions, forecast, solver, stats
 from pastas._options import options
 from pastas.dataset import list_datasets, load_dataset
 from pastas.decorators import (
-    PastasDeprecationWarning,
+    deprecate_class_func_or_method,
     get_use_cache,
     get_use_numba,
     set_use_cache,
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 register_matplotlib_converters()
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The LmfitSolve class will be removed from the pastas module namespace. Please use ps.solver.Lmfit instead.",
 )
@@ -71,7 +71,7 @@ def LmfitSolve(*args, **kwargs):
     return solver.Lmfit(*args, **kwargs)
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The EmceeSolve class will be removed from the pastas module namespace. Please use ps.solver.Emcee instead.",
 )
@@ -80,7 +80,7 @@ def EmceeSolve(*args, **kwargs):
     return solver.Emcee(*args, **kwargs)
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The LeastSquares class will be removed from the pastas module namespace. Please use ps.solver.LeastSquares instead.",
 )

--- a/pastas/__init__.py
+++ b/pastas/__init__.py
@@ -63,7 +63,7 @@ register_matplotlib_converters()
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The LmfitSolve class will be removed from the pastas module namespace. Please use ps.solver.Lmfit instead.",
 )
 def LmfitSolve(*args, **kwargs):
@@ -72,7 +72,7 @@ def LmfitSolve(*args, **kwargs):
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The EmceeSolve class will be removed from the pastas module namespace. Please use ps.solver.Emcee instead.",
 )
 def EmceeSolve(*args, **kwargs):
@@ -81,7 +81,7 @@ def EmceeSolve(*args, **kwargs):
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The LeastSquares class will be removed from the pastas module namespace. Please use ps.solver.LeastSquares instead.",
 )
 def LeastSquares(*args, **kwargs):

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -32,7 +32,7 @@ USE_NUMBA = True
 USE_CACHE = False
 
 
-def PastasDeprecationWarning(version: str, reason: str = "") -> Any:
+def deprecate_class_func_or_method(version: str, reason: str = "") -> Any:
     """Provide a warning or error when a Pastas class, method or function is deprecated.
 
     This decorator manages deprecation of classes, functions, or methods across Pastas versions.
@@ -126,7 +126,7 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
         raise TypeError(msg)
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The set_use_numba function is deprecated. Use ps.options.numba = True/False instead.",
 )
@@ -144,7 +144,7 @@ def set_use_numba(b: bool) -> None:
     USE_NUMBA = b
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The get_use_numba function is deprecated. Use ps.options.numba instead.",
 )
@@ -159,7 +159,7 @@ def get_use_numba() -> bool:
     return options.numba
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The set_use_cache function is deprecated. Use ps.options.cache = True/False instead.",
 )
@@ -187,7 +187,7 @@ def set_use_cache(b: bool) -> None:
     USE_CACHE = b
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0",
     reason="The get_use_cache function is deprecated. Use ps.options.cache instead.",
 )
@@ -350,7 +350,7 @@ def njit(function: Callable | None = None, **kwargs) -> Callable:
     return njit_decorator
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason="latexify was archived and is no longer maintained. This decorator will be removed in a future release.",
 )

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -1,6 +1,6 @@
 """Module containing decorators and utility functions for Pastas models.
 
-Includes decorators for caching, configuring global settings, deprecation warnings,
+Includes decorators for caching, configuring global settings, deprecations,
 and other convenient methods for handling time, numba compiled code, etc.
 """
 

--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -127,7 +127,7 @@ def deprecate_args_or_kwargs(name: str, version: str, reason: str = "") -> None:
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The set_use_numba function is deprecated. Use ps.options.numba = True/False instead.",
 )
 def set_use_numba(b: bool) -> None:
@@ -145,7 +145,7 @@ def set_use_numba(b: bool) -> None:
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The get_use_numba function is deprecated. Use ps.options.numba instead.",
 )
 def get_use_numba() -> bool:
@@ -160,7 +160,7 @@ def get_use_numba() -> bool:
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The set_use_cache function is deprecated. Use ps.options.cache = True/False instead.",
 )
 def set_use_cache(b: bool) -> None:
@@ -188,7 +188,7 @@ def set_use_cache(b: bool) -> None:
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0",
+    version="2.4.0",
     reason="The get_use_cache function is deprecated. Use ps.options.cache instead.",
 )
 def get_use_cache() -> bool:

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -1442,7 +1442,7 @@ class Model:
         if "s" in kwargs:
             deprecate_args_or_kwargs(
                 name="s",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Please use `oseries` instead of `s`.",
             )
             if oseries is None:
@@ -1937,7 +1937,7 @@ class Model:
         if "split" in kwargs:
             deprecate_args_or_kwargs(
                 name="split",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Use `split_contributions` instead.",
             )
             split_contributions = kwargs.pop("split")

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -37,8 +37,8 @@ from pastas.check import (
     response_memory_vs_warmup,
 )
 from pastas.decorators import (
-    deprecate_class_func_or_method,
     deprecate_args_or_kwargs,
+    deprecate_class_func_or_method,
     get_stressmodel,
 )
 from pastas.io.base import _load_model, dump

--- a/pastas/model.py
+++ b/pastas/model.py
@@ -37,7 +37,7 @@ from pastas.check import (
     response_memory_vs_warmup,
 )
 from pastas.decorators import (
-    PastasDeprecationWarning,
+    deprecate_class_func_or_method,
     deprecate_args_or_kwargs,
     get_stressmodel,
 )
@@ -227,7 +227,7 @@ class Model:
             "like ml.solve() and ml.set_settings()."
         )
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.4.0",
         reason="Stressmodels are now added by adding the Pastas Model as the first argument during stressmodel initialization (i.e., ps.Stressmodel(model=ml, *args))",
     )
@@ -292,7 +292,7 @@ class Model:
         # Reset time_offset to force recalculation when a new stressmodel is added
         self._time_offset = None
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.4.0",
         reason="Constants are now added by adding the Pastas Model as the first argument during initialization (i.e., ps.Constant(model=ml, *args))",
     )
@@ -319,7 +319,7 @@ class Model:
         self._parameters = self.get_init_parameters(initial=False)
         self._check_stressmodel_compatibility()
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.4.0",
         reason="Transforms are now added by adding the Pastas Model as the first "
         "argument during Transform initialization (i.e., ps.ThresholdTransform"
@@ -351,7 +351,7 @@ class Model:
         self._parameters = self.get_init_parameters(initial=False)
         self._check_stressmodel_compatibility()
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.4.0",
         reason="Noise models are now added by adding the Pastas Model as the first "
         "argument during noise model initialization (i.e., ps.ArNoiseModel"
@@ -391,7 +391,7 @@ class Model:
 
         self._parameters = self.get_init_parameters(initial=False)
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.4.0",
         reason="Solvers are now added by adding the Pastas Model as the first "
         "argument during solver initialization (i.e.,  ps.solver.LeastSquares"
@@ -890,7 +890,7 @@ class Model:
 
         return oseries.series
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.0.0",
         reason="The initialize method is not needed anymore in favor of the `set_settings` method.",
     )
@@ -1158,7 +1158,7 @@ class Model:
             self._generate_warnings_report(log=True, solve_success=solve_success)
 
     @property
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.0.0", reason="Use 'ml.observations()' instead."
     )
     def oseries_calib(self):

--- a/pastas/modelstats.py
+++ b/pastas/modelstats.py
@@ -15,10 +15,9 @@ This returns a Series containing the statistics::
     nse        0.929136
 """
 
-from numpy import interp, nan
-from pandas import DataFrame, Series, Timestamp
+from numpy import nan
+from pandas import DataFrame, Timestamp
 
-from pastas.timeseries_utils import _index_to_int64
 from pastas.typing import Model
 
 from .decorators import model_tmin_tmax

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -25,7 +25,7 @@ from pandas import DataFrame, DatetimeIndex, Series, Timedelta
 from pastas.typing import ArrayLike, Model
 
 from .decorators import (
-    PastasDeprecationWarning,
+    deprecate_class_func_or_method,
     check_argument_model,
     njit,
     set_parameter,
@@ -296,7 +296,7 @@ class ArNoiseModel(NoiseModelBase):
         return super().to_dict()
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason="Please use `ps.ArNoiseModel` instead.",
 )
@@ -442,7 +442,7 @@ class ArmaNoiseModel(NoiseModelBase):
         return super().to_dict()
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason="Please use `ps.ArmaNoiseModel` instead.",
 )

--- a/pastas/noisemodels.py
+++ b/pastas/noisemodels.py
@@ -25,8 +25,8 @@ from pandas import DataFrame, DatetimeIndex, Series, Timedelta
 from pastas.typing import ArrayLike, Model
 
 from .decorators import (
-    deprecate_class_func_or_method,
     check_argument_model,
+    deprecate_class_func_or_method,
     njit,
     set_parameter,
 )

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -195,7 +195,7 @@ class Plotting:
         if "split" in kwargs:
             deprecate_args_or_kwargs(
                 name="split",
-                version="2.2.0",
+                version="2.4.0",
                 reason="Use `split_contributions` instead.",
             )
             split_contributions = kwargs.pop("split")

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -7,11 +7,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.ticker import LogFormatter, MultipleLocator
-from pandas import DataFrame, Series, Timedelta, Timestamp, concat
+from pandas import DataFrame, Timedelta, Timestamp, concat
 
 from pastas.decorators import (
-    deprecate_class_func_or_method,
     deprecate_args_or_kwargs,
+    deprecate_class_func_or_method,
     model_tmin_tmax,
 )
 from pastas.plotting.plots import cum_frequency, diagnostics, pairplot, series
@@ -23,7 +23,6 @@ from pastas.plotting.plotutil import (
     plot_series_with_gaps,
     share_xaxes,
 )
-from pastas.timeseries_utils import _index_to_int64
 from pastas.typing import Axes, Figure, Model, StressModel
 
 logger = logging.getLogger(__name__)

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -396,7 +396,7 @@ class Plotting:
         return axd if return_dict else list(axd.values())
 
     @deprecate_class_func_or_method(
-        version="2.2.0", reason="Use `results` instead with the return_dict argument."
+        version="2.0.0", reason="Use `results` instead with the return_dict argument."
     )
     def results_mosaic(self, *args, **kwargs) -> dict[str, Axes]:
         """Plot the results of the model in a mosaic plot (deprecated).

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -10,7 +10,7 @@ from matplotlib.ticker import LogFormatter, MultipleLocator
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat
 
 from pastas.decorators import (
-    PastasDeprecationWarning,
+    deprecate_class_func_or_method,
     deprecate_args_or_kwargs,
     model_tmin_tmax,
 )
@@ -395,7 +395,7 @@ class Plotting:
 
         return axd if return_dict else list(axd.values())
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.2.0", reason="Use `results` instead with the return_dict argument."
     )
     def results_mosaic(self, *args, **kwargs) -> dict[str, Axes]:
@@ -947,7 +947,7 @@ class Plotting:
 
         return fig.axes
 
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="1.6.0",
         reason=(
             "Quantifying contributions in one plot is ambiguous. "

--- a/pastas/plotting/modelplots.py
+++ b/pastas/plotting/modelplots.py
@@ -544,7 +544,7 @@ class Plotting:
         if "split" in kwargs:
             deprecate_args_or_kwargs(
                 name="split",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Use `split_contributions` instead.",
             )
             split_contributions = kwargs.pop("split")

--- a/pastas/plotting/plotly.py
+++ b/pastas/plotting/plotly.py
@@ -10,7 +10,6 @@ Use Plotly for interactive plotting::
 """
 
 import numpy as np
-import pandas as pd
 import plotly.graph_objs as go
 from plotly.subplots import make_subplots
 from scipy.stats import norm, probplot
@@ -23,7 +22,6 @@ from pastas.plotting.plotutil import (
 )
 from pastas.rfunc import HantushWellModel
 from pastas.stats import acf
-from pastas.timeseries_utils import _index_to_int64
 
 
 @register_model_accessor("plotly")

--- a/pastas/plotting/plots.py
+++ b/pastas/plotting/plots.py
@@ -8,7 +8,7 @@ import numpy as np
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat
 from scipy.stats import gaussian_kde, norm, pearsonr, probplot
 
-from pastas.decorators import PastasDeprecationWarning, deprecate_args_or_kwargs
+from pastas.decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs
 from pastas.plotting.modelcompare import CompareModels
 from pastas.plotting.plotutil import plot_series_with_gaps, share_xaxes, share_yaxes
 from pastas.stats.core import acf as get_acf
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["acf", "compare", "cum_frequency", "diagnostics", "series"]
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason="The TrackSolve class has been moved to pastas.solver.trackers.TrackSolve.",
 )

--- a/pastas/plotting/plots.py
+++ b/pastas/plotting/plots.py
@@ -8,7 +8,7 @@ import numpy as np
 from pandas import DataFrame, Series, Timedelta, Timestamp, concat
 from scipy.stats import gaussian_kde, norm, pearsonr, probplot
 
-from pastas.decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs
+from pastas.decorators import deprecate_args_or_kwargs, deprecate_class_func_or_method
 from pastas.plotting.modelcompare import CompareModels
 from pastas.plotting.plotutil import plot_series_with_gaps, share_xaxes, share_yaxes
 from pastas.stats.core import acf as get_acf

--- a/pastas/plotting/plots.py
+++ b/pastas/plotting/plots.py
@@ -127,7 +127,7 @@ def series(
     if "head" in kwargs:
         deprecate_args_or_kwargs(
             name="head",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `oseries` instead of `head`.",
         )
         if oseries is None:
@@ -538,7 +538,7 @@ def cum_frequency(
     if "obs" in kwargs:
         deprecate_args_or_kwargs(
             name="obs",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `oseries` instead of `obs`.",
         )
         if oseries is None:

--- a/pastas/rcparams.py
+++ b/pastas/rcparams.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from pastas._options import options
-from pastas.decorators import PastasDeprecationWarning
+from pastas.decorators import deprecate_class_func_or_method
 
 reason = "Using ps.rcParams is deprecated. Use ps.options instead."
 
@@ -38,12 +38,12 @@ class _DeprecatedRcParams(Mapping[str, Any]):
     def __init__(self) -> None:
         self._data = options
 
-    @PastasDeprecationWarning(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
     def __getitem__(self, key: str) -> Any:
         """Get a setting value by key."""
         return self._data[key]
 
-    @PastasDeprecationWarning(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a setting value by key."""
         self._data[key] = value
@@ -72,17 +72,17 @@ class _DeprecatedRcParams(Mapping[str, Any]):
         """Return setting values."""
         return self._data.__dict__.values()
 
-    @PastasDeprecationWarning(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
     def get(self, key: str, default: Any = None) -> Any:
         """Get a setting with a default value."""
         return self._data.__dict__.get(key, default)
 
-    @PastasDeprecationWarning(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
     def pop(self, key: str, *args: Any) -> Any:
         """Remove and return a setting."""
         return self._data.__dict__.pop(key, *args)
 
-    @PastasDeprecationWarning(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
     def update(self, *args: Any, **kwargs: Any) -> None:
         """Update settings from a dictionary."""
         for key, value in dict(*args, **kwargs).items():

--- a/pastas/rcparams.py
+++ b/pastas/rcparams.py
@@ -38,12 +38,12 @@ class _DeprecatedRcParams(Mapping[str, Any]):
     def __init__(self) -> None:
         self._data = options
 
-    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.4.0", reason=reason)
     def __getitem__(self, key: str) -> Any:
         """Get a setting value by key."""
         return self._data[key]
 
-    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.4.0", reason=reason)
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a setting value by key."""
         self._data[key] = value
@@ -72,17 +72,17 @@ class _DeprecatedRcParams(Mapping[str, Any]):
         """Return setting values."""
         return self._data.__dict__.values()
 
-    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.4.0", reason=reason)
     def get(self, key: str, default: Any = None) -> Any:
         """Get a setting with a default value."""
         return self._data.__dict__.get(key, default)
 
-    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.4.0", reason=reason)
     def pop(self, key: str, *args: Any) -> Any:
         """Remove and return a setting."""
         return self._data.__dict__.pop(key, *args)
 
-    @deprecate_class_func_or_method(version="2.3.0", reason=reason)
+    @deprecate_class_func_or_method(version="2.4.0", reason=reason)
     def update(self, *args: Any, **kwargs: Any) -> None:
         """Update settings from a dictionary."""
         for key, value in dict(*args, **kwargs).items():

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -35,7 +35,7 @@ from scipy.special import (
     wrightomega,
 )
 
-from pastas.decorators import PastasDeprecationWarning, njit
+from pastas.decorators import deprecate_class_func_or_method, njit
 from pastas.stats import moment
 from pastas.typing import ArrayLike
 
@@ -3558,7 +3558,7 @@ class Spline(RfuncBase):
         return settings
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason=(
         "Please use the pastas-plugins library if you want to keep using this "

--- a/pastas/solver/base.py
+++ b/pastas/solver/base.py
@@ -56,7 +56,9 @@ class SolverBase(ABC):
         return parameters
 
     @property
-    @deprecate_class_func_or_method(version="2.4.0", reason="Use 'solver.model' instead.")
+    @deprecate_class_func_or_method(
+        version="2.4.0", reason="Use 'solver.model' instead."
+    )
     def ml(self):
         """Pastas Model instance (Deprecated)."""
         return self.model

--- a/pastas/solver/base.py
+++ b/pastas/solver/base.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pandas as pd
 
-from pastas.decorators import PastasDeprecationWarning, set_parameter
+from pastas.decorators import deprecate_class_func_or_method, set_parameter
 from pastas.typing import Model
 
 logger = getLogger(__name__)
@@ -56,7 +56,7 @@ class SolverBase(ABC):
         return parameters
 
     @property
-    @PastasDeprecationWarning(version="2.4.0", reason="Use 'solver.model' instead.")
+    @deprecate_class_func_or_method(version="2.4.0", reason="Use 'solver.model' instead.")
     def ml(self):
         """Pastas Model instance (Deprecated)."""
         return self.model
@@ -157,7 +157,7 @@ class SolverBase(ABC):
         }
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0", reason="Use SolverBase instead of BaseSolver."
 )
 class BaseSolver(SolverBase):

--- a/pastas/solver/least_squares.py
+++ b/pastas/solver/least_squares.py
@@ -12,7 +12,7 @@ from pandas import DataFrame, Series
 from scipy.linalg import LinAlgError, get_lapack_funcs, svd
 from scipy.optimize import Bounds, OptimizeResult, least_squares
 
-from pastas.decorators import PastasDeprecationWarning, temporarily_disable_cache
+from pastas.decorators import deprecate_class_func_or_method, temporarily_disable_cache
 from pastas.plotting.plotutil import _table_formatter_stderr
 from pastas.typing import ArrayLike, Model
 
@@ -1088,7 +1088,7 @@ class LeastSquares(LeastSquaresBase):
         return settings
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0", reason="The LmfitSolve class is renamed to Lmfit."
 )
 def LmfitSolve(*args, **kwargs):

--- a/pastas/solver/least_squares.py
+++ b/pastas/solver/least_squares.py
@@ -1089,7 +1089,7 @@ class LeastSquares(LeastSquaresBase):
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0", reason="The LmfitSolve class is renamed to Lmfit."
+    version="2.4.0", reason="The LmfitSolve class is renamed to Lmfit."
 )
 def LmfitSolve(*args, **kwargs):
     """Alias for Lmfit."""

--- a/pastas/solver/mcmc.py
+++ b/pastas/solver/mcmc.py
@@ -19,7 +19,7 @@ logger = getLogger(__name__)
 
 
 @deprecate_class_func_or_method(
-    version="2.3.0", reason="The EmceeSolve class is renamed to Emcee."
+    version="2.4.0", reason="The EmceeSolve class is renamed to Emcee."
 )
 def EmceeSolve(*args, **kwargs):
     """Alias for Emcee class."""

--- a/pastas/solver/mcmc.py
+++ b/pastas/solver/mcmc.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 from pandas import DataFrame, Series
 
-from pastas.decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs
+from pastas.decorators import deprecate_args_or_kwargs, deprecate_class_func_or_method
 from pastas.typing import ArrayLike, CallBack, Model
 
 from .._options import options

--- a/pastas/solver/mcmc.py
+++ b/pastas/solver/mcmc.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 from pandas import DataFrame, Series
 
-from pastas.decorators import PastasDeprecationWarning, deprecate_args_or_kwargs
+from pastas.decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs
 from pastas.typing import ArrayLike, CallBack, Model
 
 from .._options import options
@@ -18,7 +18,7 @@ from .objective_function import misfit
 logger = getLogger(__name__)
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.3.0", reason="The EmceeSolve class is renamed to Emcee."
 )
 def EmceeSolve(*args, **kwargs):

--- a/pastas/solver/timer.py
+++ b/pastas/solver/timer.py
@@ -21,12 +21,12 @@ This will print the following to the console::
 
 from typing import Any, Literal
 
-from pastas.decorators import PastasDeprecationWarning
+from pastas.decorators import deprecate_class_func_or_method
 from pastas.stats import metrics
 from pastas.typing import ArrayLike, Model
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason="The ExceededMaxSolveTime exception has been renamed to TimeoutError.",
 )

--- a/pastas/solver/trackers.py
+++ b/pastas/solver/trackers.py
@@ -144,7 +144,7 @@ class TrackSolve:
         if "params" in kwargs:
             deprecate_args_or_kwargs(
                 "params",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Params is renamed to p and will be removed in a future version.",
             )
             p = kwargs.pop("params")
@@ -197,7 +197,7 @@ class TrackSolve:
         if "params" in kwargs:
             deprecate_args_or_kwargs(
                 "params",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Params is renamed to p and will be removed in a future version.",
             )
             p = kwargs.pop("params")
@@ -220,7 +220,7 @@ class TrackSolve:
         if "params" in kwargs:
             deprecate_args_or_kwargs(
                 "params",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Params is renamed to p and will be removed in a future version.",
             )
             p = kwargs.pop("params")
@@ -373,7 +373,7 @@ class TrackSolve:
         if "params" in kwargs:
             deprecate_args_or_kwargs(
                 "params",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Params is renamed to p and will be removed in a future version.",
             )
             p = kwargs.pop("params")

--- a/pastas/stats/core.py
+++ b/pastas/stats/core.py
@@ -97,7 +97,7 @@ def acf(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:
@@ -204,7 +204,7 @@ def ccf(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series_x` instead of `x`.",
         )
         if series_x is None:
@@ -214,7 +214,7 @@ def ccf(
     if "y" in kwargs:
         deprecate_args_or_kwargs(
             name="y",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series_y` instead of `y`.",
         )
         if series_y is None:
@@ -302,7 +302,7 @@ def _preprocess(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:
@@ -459,7 +459,7 @@ def mean(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:
@@ -512,7 +512,7 @@ def var(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:
@@ -558,7 +558,7 @@ def std(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:
@@ -592,7 +592,7 @@ def moment(series: Series | None = None, order: int = 0, **kwargs) -> float:
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:
@@ -641,7 +641,7 @@ def _get_weights(
     if "x" in kwargs:
         deprecate_args_or_kwargs(
             name="x",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `x`.",
         )
         if series is None:

--- a/pastas/stats/metrics.py
+++ b/pastas/stats/metrics.py
@@ -18,7 +18,7 @@ from numpy import abs as npabs
 from numpy import average, log, nan, sqrt
 from pandas import DataFrame, Series
 
-from pastas.decorators import PastasDeprecationWarning
+from pastas.decorators import deprecate_class_func_or_method
 from pastas.stats.core import _get_weights, mean, std, var
 
 __all__ = [
@@ -765,7 +765,7 @@ def kge(
     return kge
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.0.0",
     reason="""This function `kge_2012` will be deprecated in Pastas version 2.0. Please
     use `pastas.stats.kge(modified=True)` to get the same outcome.""",

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -35,10 +35,10 @@ from pastas.typing import (
 )
 
 from .decorators import (
-    deprecate_class_func_or_method,
     check_argument_model,
     conditional_cachedmethod,
     deprecate_args_or_kwargs,
+    deprecate_class_func_or_method,
     njit,
     set_parameter,
 )

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -892,16 +892,16 @@ class LinearTrend(StressModelBase):
         if start is not None:
             deprecate_args_or_kwargs(
                 "start",
-                "3.0.0",
-                "Please use 'tstart' instead of 'start'.",
+                version="2.4.0",
+                reason="Please use 'tstart' instead of 'start'.",
             )
             if tstart is None:
                 tstart = start
         if end is not None:
             deprecate_args_or_kwargs(
                 "end",
-                "3.0.0",
-                "Please use 'tend' instead of 'end'.",
+                version="2.4.0",
+                reason="Please use 'tend' instead of 'end'.",
             )
             if tend is None:
                 tend = end

--- a/pastas/stressmodels.py
+++ b/pastas/stressmodels.py
@@ -35,7 +35,7 @@ from pastas.typing import (
 )
 
 from .decorators import (
-    PastasDeprecationWarning,
+    deprecate_class_func_or_method,
     check_argument_model,
     conditional_cachedmethod,
     deprecate_args_or_kwargs,
@@ -141,7 +141,7 @@ class StressModelBase(ABC):
         """Number of time series the contribution can be split in."""
 
     @property
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.0.0",
         reason=(
             "The get_nsplit method is deprecated. To inspect the number of available split"
@@ -163,7 +163,7 @@ class StressModelBase(ABC):
         return self.parameters.index.size
 
     @property
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.0.0",
         reason=(
             "The freq attribute is deprecated. To inspect the model frequency "
@@ -1952,7 +1952,7 @@ class RechargeModel(StressModelBase):
             logger.warning(msg)
 
     @property
-    @PastasDeprecationWarning(
+    @deprecate_class_func_or_method(
         version="2.0.0",
         reason=(
             "for the RechargeModel. Use 'stresses' property instead if you want to"

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -379,7 +379,7 @@ def get_sample_for_freq(
 
 
 @deprecate_class_func_or_method(
-    version="2.1",
+    version="2.0.0",
     reason="`timestep_weighted_resample` is replaced by `time_weighted_resample`.",
 )
 def timestep_weighted_resample(
@@ -390,7 +390,7 @@ def timestep_weighted_resample(
 ) -> Series:
     """Resample a time series to a new time index, using an overlapping period weighted average.
 
-    .. deprecated:: 2.1
+    .. deprecated:: 2.0.0
         Use :func:`time_weighted_resample` instead.
 
     The original series and the new index do not have to be equidistant. Also, the

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -23,7 +23,7 @@ from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import BaseOffset
 from scipy import interpolate
 
-from .decorators import PastasDeprecationWarning, deprecate_args_or_kwargs, njit
+from .decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs, njit
 
 logger = logging.getLogger(__name__)
 
@@ -378,7 +378,7 @@ def get_sample_for_freq(
     return series.loc[get_sample(series.index, ref_tindex)]
 
 
-@PastasDeprecationWarning(
+@deprecate_class_func_or_method(
     version="2.1",
     reason="`timestep_weighted_resample` is replaced by `time_weighted_resample`.",
 )

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -354,7 +354,7 @@ def get_sample_for_freq(
     if "s" in kwargs:
         deprecate_args_or_kwargs(
             name="s",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `s`.",
         )
         if series is None:
@@ -425,7 +425,7 @@ def timestep_weighted_resample(
     if "s" in kwargs:
         deprecate_args_or_kwargs(
             name="s",
-            version="2.3.0",
+            version="2.4.0",
             reason="Please use `series` instead of `s`.",
         )
         if series is None:

--- a/pastas/timeseries_utils.py
+++ b/pastas/timeseries_utils.py
@@ -23,7 +23,7 @@ from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import BaseOffset
 from scipy import interpolate
 
-from .decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs, njit
+from .decorators import deprecate_args_or_kwargs, deprecate_class_func_or_method, njit
 
 logger = logging.getLogger(__name__)
 

--- a/pastas/transform.py
+++ b/pastas/transform.py
@@ -178,7 +178,7 @@ class ThresholdTransform:
         if "h" in kwargs:
             deprecate_args_or_kwargs(
                 name="h",
-                version="2.3.0",
+                version="2.4.0",
                 reason="Please use `series` instead of `h`.",
             )
             if series is None:

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -2,14 +2,14 @@ from typing import Any
 
 import pytest
 
-from pastas.decorators import PastasDeprecationWarning, deprecate_args_or_kwargs
+from pastas.decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs
 
 msg = "Boo!"
 
 
 def test_class_deprecation() -> None:
     # class will be removed in future version - should show a FutureWarning
-    @PastasDeprecationWarning(version="999.0.0", reason=msg)
+    @deprecate_class_func_or_method(version="999.0.0", reason=msg)
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
@@ -18,7 +18,7 @@ def test_class_deprecation() -> None:
         Deprecated(1)  # logs warning, continues execution
 
     # class was already removed (version <= current) - should raise AttributeError
-    @PastasDeprecationWarning(version="0.1.0", reason=msg)
+    @deprecate_class_func_or_method(version="0.1.0", reason=msg)
     class Deprecated:
         def __init__(self, a: Any) -> None:
             self.a = a
@@ -33,7 +33,7 @@ def test_classmethod_deprecation() -> None:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(version="999.0.0", reason=msg)
+        @deprecate_class_func_or_method(version="999.0.0", reason=msg)
         def foo(self, b: Any) -> Any:
             return self.a + b
 
@@ -46,7 +46,7 @@ def test_classmethod_deprecation() -> None:
         def __init__(self, a: Any) -> None:
             self.a = a
 
-        @PastasDeprecationWarning(version="0.1.0", reason=msg)
+        @deprecate_class_func_or_method(version="0.1.0", reason=msg)
         def foo(self, b: Any) -> Any:
             return self.a + b
 
@@ -57,7 +57,7 @@ def test_classmethod_deprecation() -> None:
 
 def test_function_deprecation() -> None:
     # function will be removed in future version - should show a FutureWarning
-    @PastasDeprecationWarning(version="999.0.0", reason=msg)
+    @deprecate_class_func_or_method(version="999.0.0", reason=msg)
     def foo(a: Any) -> None:
         print(a)
 
@@ -65,7 +65,7 @@ def test_function_deprecation() -> None:
         foo(1)  # shows warning, continues execution
 
     # function was already removed (version <= current) - should raise AttributeError
-    @PastasDeprecationWarning(version="0.1.0", reason=msg)
+    @deprecate_class_func_or_method(version="0.1.0", reason=msg)
     def foo(a: Any) -> None:
         print(a)
 

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from pastas.decorators import deprecate_class_func_or_method, deprecate_args_or_kwargs
+from pastas.decorators import deprecate_args_or_kwargs, deprecate_class_func_or_method
 
 msg = "Boo!"
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -55,12 +55,14 @@ def test_results_kwargs_split_deprecation(ml_noisemodel: Model) -> None:
 
 
 def test_results_mosaic(ml_noisemodel: Model) -> None:
-    _ = ml_noisemodel.plots.results_mosaic(stderr=True, all_responses=False)
+    with pytest.warns(FutureWarning, match="return_dict"):
+        _ = ml_noisemodel.plots.results_mosaic(stderr=True, all_responses=False)
     plt.close()
 
 
 def test_results_mosaic_split(ml_noisemodel: Model) -> None:
-    _ = ml_noisemodel.plots.results_mosaic(split_contributions=True)
+    with pytest.warns(FutureWarning, match="return_dict"):
+        _ = ml_noisemodel.plots.results_mosaic(split_contributions=True)
     plt.close()
 
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -55,13 +55,13 @@ def test_results_kwargs_split_deprecation(ml_noisemodel: Model) -> None:
 
 
 def test_results_mosaic(ml_noisemodel: Model) -> None:
-    with pytest.warns(FutureWarning, match="return_dict"):
+    with pytest.raises(AttributeError, match="return_dict"):
         _ = ml_noisemodel.plots.results_mosaic(stderr=True, all_responses=False)
     plt.close()
 
 
 def test_results_mosaic_split(ml_noisemodel: Model) -> None:
-    with pytest.warns(FutureWarning, match="return_dict"):
+    with pytest.raises(AttributeError, match="return_dict"):
         _ = ml_noisemodel.plots.results_mosaic(split_contributions=True)
     plt.close()
 


### PR DESCRIPTION
# Short description
Makes the deprecations for Pastas 2.0 consistent:
- Deprecation is either at version 2.4 for future depreactions
- Else it is version 2.0 or earlier

Rename `PastasDeprecationWarning` to `deprecate_class_func_or_method` because we don't use DeprecationWarning anymore but future warnign. Also it is more consistent with the `deprecate_args_or_kwargs`. 

# Checklist before PR can be merged:
- [x] closes issue #1276, #701 