### PR TITLE
Fix Packaging 25 version normalization

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -11,6 +11,7 @@ from logging import getLogger
 from typing import Any
 from warnings import warn
 
+from packaging.version import Version
 from packaging.version import parse as parse_version
 from pandas import Timestamp
 
@@ -24,10 +25,14 @@ except (ModuleNotFoundError, ImportError):
     CACHETOOLS_AVAILABLE = False
 
 logger = getLogger(__name__)
+
+
+def _get_base_version(version: str) -> Version:
+    return parse_version(parse_version(version).base_version)
+
+
 # Test against base-version, formatted as a Version (.base_version returns a str)
-CURRENT_PASTAS_VERSION = parse_version(__version__).__replace__(
-    pre=None, post=None, dev=None, local=None
-)
+CURRENT_PASTAS_VERSION = _get_base_version(__version__)
 
 # Keep these for backward compatibility but they now delegate to central settings
 # These will be removed in a future version 2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ maintainers = [
 ]
 requires-python = ">= 3.11, < 3.15"
 dependencies = [
+    "packaging >= 25.0",
     "numpy >= 2.0.0, < 3.0",
     "matplotlib >= 3.9.0, < 4.0",
     "pandas >= 2.2.0, < 4.0",

--- a/tests/test_deprecator.py
+++ b/tests/test_deprecator.py
@@ -1,10 +1,39 @@
 from typing import Any
 
 import pytest
+from packaging.version import Version
 
-from pastas.decorators import deprecate_args_or_kwargs, deprecate_class_func_or_method
+from pastas.decorators import (
+    CURRENT_PASTAS_VERSION,
+    _get_base_version,
+    deprecate_args_or_kwargs,
+    deprecate_class_func_or_method,
+)
+from pastas.version import __version__
 
 msg = "Boo!"
+
+
+def test_base_version_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    version = _get_base_version("1!2.3.4rc1.post2.dev3+local")
+
+    assert version == Version("1!2.3.4")
+    assert version.epoch == 1
+    assert version.release == (2, 3, 4)
+    assert version.pre is version.post is version.dev is version.local is None
+    assert _get_base_version(version.base_version) == version
+    assert CURRENT_PASTAS_VERSION == _get_base_version(__version__)
+
+    monkeypatch.setattr("pastas.decorators.CURRENT_PASTAS_VERSION", version)
+
+    @deprecate_class_func_or_method(version="1!2.3.4", reason=msg)
+    def deprecated() -> None:
+        pass
+
+    with pytest.raises(AttributeError, match=msg):
+        deprecated()
+    with pytest.raises(TypeError, match=msg):
+        deprecate_args_or_kwargs("test", version="1!2.3.4", reason=msg)
 
 
 def test_class_deprecation() -> None:


### PR DESCRIPTION
# Short description

Replace the private `Version.__replace__` call with the public `base_version` API, while preserving a parsed `Version` for deprecation comparisons. Declare `packaging>=25.0` as a direct runtime dependency and add regression coverage for qualified versions.

Closes #1326.

# Validation

- `pytest tests/test_deprecator.py -q` (5 passed)
- `pytest tests -m "not notebooks and not bnotebooks and not pasfiles" -q` (547 passed, 72 deselected)
- `ruff check pastas/decorators.py tests/test_deprecator.py`
- `pip check`

# Checklist before PR can be merged:

- [x] closes issue #1326
- [x] is documented (the public behavior is unchanged; no user-facing docs are needed)
- [x] code formatted and linted with Ruff
- [x] type hints
- [x] tests added or expanded
- [x] remove output for all notebooks with changes (no notebooks changed)
- [x] example notebook (not applicable to this bug fix)
