### PR TITLE
Fix brentq failure in Hantush response check for small gain values

### DIFF
--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1059,14 +1059,21 @@ class Hantush(RfuncBase):
         tmax = wrightomega(log_z).real * a
         return tmax
 
-    def _f_step(self, t: float, A: float, a: float, b: float, cutoff: float) -> float:
-        """Objective function for root finding (t varies, other params fixed)."""
+    def _f_step(self, t: float, a: float, b: float, cutoff: float) -> float:
+        """Objective function for root finding (t varies, other params fixed).
+
+        This function computes the difference between the step response at time t
+        and the specified cutoff. It is used in root-finding algorithms to determine
+        the time t at which the step response reaches the cutoff value.
+        """
         t_arr = np.array([t], dtype=float)
+        A = 1.0
         if self.quad:
             step_val = self.quad_step(A=A, a=a, b=b, t=t_arr)[0]
         else:
             step_val = self.numpy_step(A=A, a=a, b=b, t=t_arr)[0]
-        return (step_val / A) - cutoff
+        # would actually be (step_val / A - cutoff) but A=1.0 so it's the same
+        return step_val - cutoff
 
     def get_tmax(self, p: ArrayLike, cutoff: float | None = None) -> float:
         """Calculate `tmax` using either the approximation or root finding.
@@ -1096,11 +1103,11 @@ class Hantush(RfuncBase):
         tol = min(10.0 ** np.floor(np.log10(t0)) / 1e2, 0.1)
         root, info = brentq(
             f=self._f_step,
-            a=1e-30,  # avoid divide by zero warnings
+            a=1e-30,  # choose a small positive lower bound to avoid division by zero
             b=t0,
             xtol=tol,
             maxiter=100,  # generally converges within 10 iterations
-            args=(A, a, b, cutoff),
+            args=(a, b, cutoff),
             full_output=True,
             disp=False,
         )

--- a/pastas/rfunc.py
+++ b/pastas/rfunc.py
@@ -1097,7 +1097,7 @@ class Hantush(RfuncBase):
         if self.approximate_tmax:
             return t0
 
-        A, a, b = p[0], p[1], p[2]
+        a, b = p[1], p[2]
 
         # Use Brentq's method
         tol = min(10.0 ** np.floor(np.log10(t0)) / 1e2, 0.1)


### PR DESCRIPTION
# Short description
The true response length is calculated in the `check` module for `Hantush` and `HantushWellModel`. The true length corresponds to the point where the step response reaches the gain multiplied by the specified cutoff.

However, when the gain $A$ is extremely small, numerical underflow causes the `brentq` root-finding algorithm to fail. Since the cutoff calculation is normalized, the actual gain value is not required. Setting $A=1.0$ resolves the underflow issue and allows `brentq` to converge reliably.

# Checklist before PR can be merged:
- [x] closes issue #1328 