### PR TITLE
Fix parsing versions and their checks

### DIFF
--- a/pastas/decorators.py
+++ b/pastas/decorators.py
@@ -24,13 +24,11 @@ except (ModuleNotFoundError, ImportError):
     CACHETOOLS_AVAILABLE = False
 
 logger = getLogger(__name__)
-# Test against base-version, formatted as a Version (.base_version returns a str)
-CURRENT_PASTAS_VERSION = parse_version(__version__).__replace__(
-    pre=None, post=None, dev=None, local=None
-)
+
+CURRENT_PASTAS_VERSION = parse_version(parse_version(__version__).base_version)
 
 # Keep these for backward compatibility but they now delegate to central settings
-# These will be removed in a future version 2.3.0
+# These will be removed in a future version 2.4.0
 USE_NUMBA = True
 USE_CACHE = False
 

--- a/pastas/io/base.py
+++ b/pastas/io/base.py
@@ -14,7 +14,7 @@ from logging import getLogger
 from os import path
 from pathlib import Path
 
-from packaging import version
+from packaging.version import parse as parse_version
 
 import pastas as ps
 from pastas.typing import Model
@@ -58,7 +58,7 @@ def load(fname: str | Path, **kwargs) -> Model:
     file_version = data["file_info"]["pastas_version"]
 
     # A single catch for old pas-files, no longer supported
-    if version.parse(file_version) < version.parse("0.23.0"):
+    if parse_version(file_version) < parse_version("0.23.0"):
         msg = (
             "This file was created with a Pastas version prior to 0.23 "
             "and cannot be loaded with Pastas >= 1.0. Please load and "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pandas >= 2.2.0, < 4.0",
     "scipy >= 1.16.0, < 2.0",
     "numba >= 0.60.0, < 1.0",
+    "packaging >= 20.0.0"
 ]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [


### PR DESCRIPTION
# Short description
I discussed this with @dbrakenhoff yesterday. We should probably just add `packaging` as a dependency. This is the easiest solution, as we already use packaging in that way. That way, even if matplotlib drops support, we still have it properly installed.

The only other thing we could do is to do something like this with regex:
```python
import re
def parse_version(version: str) -> tuple[int, ...]:
    """Parse version string into integer tuple, ignoring pre/post/dev/local tags."""
    match = re.match(r"^(\d+(?:\.\d+)*)", str(version).strip())
    return tuple(map(int, match.group(1).split("."))) if match else (0, 0, 0)
```

# Checklist before PR can be merged:
- [x] closes issue #1326