### PR TITLE
retain headers from forecast data in groundwater forecast and allow different sim freqs

### DIFF
--- a/doc/examples/ensemble_predictions.ipynb
+++ b/doc/examples/ensemble_predictions.ipynb
@@ -14,7 +14,7 @@
                 "\n",
                 "<div class=\"alert alert-info\">\n",
                 "<b>Note:</b>\n",
-                "Collenteur et al. (In submission) Ensemble groundwater predictions (EGP) in alluvial aquifers in Switzerland.\n",
+                "Collenteur, R. A., Bogner, K., Zappa, M., Schirmer, M., and Moeck, C.: An ensemble groundwater prediction (EGP) system to forecast groundwater levels in alluvial aquifers in Switzerland, EGUsphere [preprint], https://doi.org/10.5194/egusphere-2025-4653, 2025\n",
                 "</div>\n",
                 "\n",
                 "## 0. Import Python Packages"

--- a/pastas/forecast.py
+++ b/pastas/forecast.py
@@ -222,10 +222,10 @@ def forecast(
 
     residuals = {}
     vars = {}
-    day = Timedelta("1D")
+    sim_freq = Timedelta(f"1{model.settings['freq']}")
 
     if post_process:
-        dt = model.settings["freq_obs"] / day
+        dt = model.settings["freq_obs"] / Timedelta("1D")
         t = linspace(1, index.size, index.size)
         correction = {}
 
@@ -258,7 +258,9 @@ def forecast(
             for stress_name, fc in fc_data.items():
                 if isinstance(fc, Series):
                     fc = fc.to_frame()
-                old_stress = getattr(sm, stress_name).series_original.loc[: tmin - day]
+                old_stress = getattr(sm, stress_name).series_original.loc[
+                    : tmin - sim_freq
+                ]
                 new_stress = fc.iloc[:, member]
                 ts = concat([old_stress, new_stress], axis=0)
                 setattr(sm, stress_name, ts)

--- a/pastas/forecast.py
+++ b/pastas/forecast.py
@@ -108,15 +108,6 @@ def _check_forecast_data(
                 index = fc.index
                 columns = fc.columns.get_level_values(0).unique().tolist()
                 logger.debug(f"First forecast found with {n} ensemble members")
-            # If the number of columns is not the same, raise an error
-            if columns != fc.columns.get_level_values(0).unique().tolist():
-                msg = (
-                    f"The column names of the forecasts are not the same for all "
-                    f"Expected {columns}, got {fc.columns.get_level_values(0).unique().tolist()} in "
-                    f"stressmodel '{sm_name}'."
-                )
-                logger.debug(msg)
-                columns = range(n)  # Reset columns to a range of integers
             elif n != fc.columns.size:
                 msg = (
                     f"The number of ensemble members is not the same for all forecasts. "
@@ -131,6 +122,15 @@ def _check_forecast_data(
                 )
                 logger.error(msg)
                 raise ValueError(msg)
+            # If the number of columns is not the same, raise an error
+            if columns != fc.columns.get_level_values(0).unique().tolist():
+                msg = (
+                    f"The column names of the forecasts are not the same for all "
+                    f"Expected {columns}, got {fc.columns.get_level_values(0).unique().tolist()} in "
+                    f"stressmodel '{sm_name}'."
+                )
+                logger.debug(msg)
+                columns = range(n)  # Reset columns to a range of integers
 
     if n is None:
         msg = "No valid forecast data found in any of the stressmodels"

--- a/pastas/forecast.py
+++ b/pastas/forecast.py
@@ -32,7 +32,7 @@ logger = getLogger(__name__)
 def _check_forecast_data(
     forecasts: dict[str, list[DataFrame | Series]]
     | dict[str, dict[str, DataFrame | Series]],
-) -> tuple[int, Timestamp | str, Timestamp | str, DatetimeIndex]:
+) -> tuple[int, Timestamp | str, Timestamp | str, DatetimeIndex, list]:
     """Check the integrity of the forecasts data.
 
     Parameters
@@ -52,6 +52,8 @@ def _check_forecast_data(
         The maximum datetime in the forecasts.
     index: DatetimeIndex
         The datetime index of the forecasts.
+    columns: list
+        The list of column names of the forecasts.
 
     Notes
     -----
@@ -70,6 +72,7 @@ def _check_forecast_data(
     tmax = None
     tmin = None
     index = None
+    columns = None
 
     for sm_name, fc_data in forecasts.items():
         if isinstance(fc_data, list):
@@ -103,8 +106,17 @@ def _check_forecast_data(
                 tmin = fc.index[0]
                 tmax = fc.index[-1]
                 index = fc.index
+                columns = fc.columns.get_level_values(0).unique().tolist()
                 logger.debug(f"First forecast found with {n} ensemble members")
             # If the number of columns is not the same, raise an error
+            if columns != fc.columns.get_level_values(0).unique().tolist():
+                msg = (
+                    f"The column names of the forecasts are not the same for all "
+                    f"Expected {columns}, got {fc.columns.get_level_values(0).unique().tolist()} in "
+                    f"stressmodel '{sm_name}'."
+                )
+                logger.debug(msg)
+                columns = range(n)  # Reset columns to a range of integers
             elif n != fc.columns.size:
                 msg = (
                     f"The number of ensemble members is not the same for all forecasts. "
@@ -125,7 +137,7 @@ def _check_forecast_data(
         logger.error(msg)
         raise ValueError(msg)
 
-    return n, tmin, tmax, index
+    return n, tmin, tmax, index, columns
 
 
 def forecast(
@@ -176,7 +188,7 @@ def forecast(
         keys are the keyword arguments of the stressmodel.
     """
     # Check the integrity of the forecasts data
-    n, tmin, tmax, index = _check_forecast_data(forecasts)
+    n, tmin, tmax, index, columns = _check_forecast_data(forecasts)
     logger.info(f"Working with {n} ensemble members from {tmin} to {tmax}")
 
     if post_process and not isinstance(model.noisemodel, ArNoiseModel):
@@ -266,7 +278,7 @@ def forecast(
 
     # Create DataFrames to store data
     mi = MultiIndex.from_product(
-        [range(n), range(nparam), ["mean", "var"]],
+        [columns, range(nparam), ["mean", "var"]],
         names=["ensemble_member", "param_member", "forecast"],
     )
     df = DataFrame(data=result_array.T, index=index, columns=mi, dtype=float)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -70,11 +70,12 @@ class TestCheckForecastData:
         df1: DataFrame = pd.DataFrame(np.random.rand(10, 3), index=index)
         df2: DataFrame = pd.DataFrame(np.random.rand(10, 3), index=index)
         forecasts: dict[str, dict[str, DataFrame]] = {"sm1": {"prec": df1, "evap": df2}}
-        n, tmin, tmax, result_index = _check_forecast_data(forecasts)
+        n, tmin, tmax, result_index, columns = _check_forecast_data(forecasts)
         assert n == 3
         assert tmin == index[0]
         assert tmax == index[-1]
         assert (result_index == index).all()
+        assert (columns == df1.columns).all()
 
     def test_series_input(self) -> None:
         """Test that a Series is converted to a 1-column DataFrame."""
@@ -82,11 +83,12 @@ class TestCheckForecastData:
         s1: Series = pd.Series(np.random.rand(10), index=index)
         s2: Series = pd.Series(np.random.rand(10), index=index)
         forecasts: dict[str, dict[str, DataFrame]] = {"sm1": {"prec": s1, "evap": s2}}
-        n, tmin, tmax, result_index = _check_forecast_data(forecasts)
+        n, tmin, tmax, result_index, columns = _check_forecast_data(forecasts)
         assert n == 1
         assert tmin == index[0]
         assert tmax == index[-1]
         assert (result_index == index).all()
+        assert (columns == s1.to_frame().columns).all()
 
 
 class TestGetOverallMeanAndVariance:


### PR DESCRIPTION
# Short description
retain headers from forecast data in groundwater forecast and allow different time steps.

# Checklist before PR can be merged:
- [x] closes issue #1090
- [x] closes issue #1101
