### PR TITLE
Add observation sampling example to time series preparation notebook

### DIFF
--- a/doc/examples/prepare_timeseries.ipynb
+++ b/doc/examples/prepare_timeseries.ipynb
@@ -660,6 +660,49 @@
   {
    "attachments": {},
    "cell_type": "markdown",
+   "id": "a2fe159d",
+   "metadata": {},
+   "source": [
+    "#### Sampling observations to a lower frequency\n",
+    "\n",
+    "For an existing groundwater-level series, `get_sample_for_freq` selects the\n",
+    "observations nearest to a regular reference index. The selected values retain\n",
+    "their original timestamps; the function does not interpolate values or shift\n",
+    "measurements onto the reference index. Here we sample daily observations from\n",
+    "the Wagna dataset approximately every 14 days."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31087dbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = ps.load_dataset(\"collenteur_2021\")[\"wagna\"]\n",
+    "head = data[\"head [m]\"].dropna().loc[\"2010\":\"2012\"]\n",
+    "head_14d = ps.ts.get_sample_for_freq(head, freq=\"14D\")\n",
+    "\n",
+    "ax = head.plot(marker=\".\", alpha=0.5, label=\"daily observations\")\n",
+    "head_14d.plot(ax=ax, marker=\"o\", linestyle=\"none\", label=\"14-day sample\")\n",
+    "ax.set_ylabel(\"head [m]\")\n",
+    "ax.legend()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "543949c4",
+   "metadata": {},
+   "source": [
+    "Because each sampled point comes from the original series, this method is useful\n",
+    "when the measured values and timestamps must be preserved. Use an interpolation\n",
+    "or aggregation method instead when values are required at exact regular timestamps."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
    "id": "2cb59811",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Add a worked groundwater-observation sampling example to `prepare_timeseries.ipynb`, using the Wagna dataset and plotting the original observations alongside an approximately 14-day sample. The explanation makes clear that sampling preserves measured values and their original timestamps, rather than interpolating onto a regular index.

Refs #839. The issue names `get_sample`; this example uses its `get_sample_for_freq` wrapper, which creates the regular reference index and delegates to `get_sample`, so readers can select observations directly from their Series.

Validation: the new cell executed successfully and preserved the source values and timestamps (79 sampled observations from 1,095). Notebook JSON, Ruff lint/format, and diff checks passed. The normal full HTML documentation build (`python -m sphinx -b html doc <output>`) passed with 247 warnings using Python 3.14.3 and the unchanged repository configuration; the changed notebook executed in 13.61 seconds and its new example and plot rendered.

The additional strict `-W` build failed with 247 warnings. Paired builds with notebook execution disabled produced identical structural warning output at the base commit and with this change (239 warnings in each Sphinx summary; 226 displayed warning lines). No execution-enabled baseline comparison was run. The existing full build also reports a timeout in another example and unsupported rich-output MIME warnings; a passing normal build does not mean every notebook executes without errors.

Prepared with Codex assistance and independently reviewed with Claude.

<!-- hermes-labs:attribution v1 -->
<!-- hermes-labs:selection autonomous -->
This contribution was autonomously selected and produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->